### PR TITLE
feat: add any port data type

### DIFF
--- a/backend/src/components/components.controller.ts
+++ b/backend/src/components/components.controller.ts
@@ -127,7 +127,7 @@ export class ComponentsController {
                           type: 'array',
                           items: {
                             type: 'string',
-                            enum: ['text', 'secret', 'number', 'boolean', 'file', 'json'],
+                            enum: ['any', 'text', 'secret', 'number', 'boolean', 'file', 'json'],
                           },
                         },
                       },
@@ -163,7 +163,7 @@ export class ComponentsController {
                           type: 'array',
                           items: {
                             type: 'string',
-                            enum: ['text', 'secret', 'number', 'boolean', 'file', 'json'],
+                            enum: ['any', 'text', 'secret', 'number', 'boolean', 'file', 'json'],
                           },
                         },
                       },
@@ -290,7 +290,7 @@ export class ComponentsController {
                         type: 'array',
                         items: {
                           type: 'string',
-                          enum: ['text', 'secret', 'number', 'boolean', 'file', 'json'],
+                          enum: ['any', 'text', 'secret', 'number', 'boolean', 'file', 'json'],
                         },
                       },
                     },
@@ -326,7 +326,7 @@ export class ComponentsController {
                         type: 'array',
                         items: {
                           type: 'string',
-                          enum: ['text', 'secret', 'number', 'boolean', 'file', 'json'],
+                          enum: ['any', 'text', 'secret', 'number', 'boolean', 'file', 'json'],
                         },
                       },
                     },

--- a/backend/src/dsl/port-utils.ts
+++ b/backend/src/dsl/port-utils.ts
@@ -31,6 +31,14 @@ function canCoercePrimitive(source: PrimitivePort, target: PrimitivePort): boole
 }
 
 function comparePortDataTypes(source: PortDataType, target: PortDataType): boolean {
+  if (isPrimitive(target) && target.name === 'any') {
+    return true;
+  }
+
+  if (isPrimitive(source) && source.name === 'any') {
+    return true;
+  }
+
   if (isPrimitive(source) && isPrimitive(target)) {
     return canCoercePrimitive(source, target);
   }
@@ -77,6 +85,8 @@ export function describePortDataType(dataType: PortDataType): string {
 export function runtimeInputTypeToPortDataType(type: string): PortDataType {
   const normalized = type.toLowerCase();
   switch (normalized) {
+    case 'any':
+      return { kind: 'primitive', name: 'any' };
     case 'text':
     case 'string':
       return { kind: 'primitive', name: 'text' };
@@ -121,6 +131,8 @@ export function createPlaceholderForPort(dataType?: PortDataType): unknown {
         return {};
       case 'json':
         return {};
+      case 'any':
+        return null;
       default:
         return null;
     }

--- a/frontend/src/schemas/component.ts
+++ b/frontend/src/schemas/component.ts
@@ -6,7 +6,7 @@ export const ComponentRunnerSchema = z
   })
   .passthrough()
 
-const PrimitivePortTypes = ['text', 'secret', 'number', 'boolean', 'file', 'json'] as const
+const PrimitivePortTypes = ['any', 'text', 'secret', 'number', 'boolean', 'file', 'json'] as const
 
 export const PrimitivePortTypeEnum = z.enum(PrimitivePortTypes)
 

--- a/frontend/src/utils/portUtils.ts
+++ b/frontend/src/utils/portUtils.ts
@@ -1,6 +1,7 @@
 import type { InputPort, PortDataType } from '@/schemas/component'
 
 const primitiveLabelMap: Record<string, string> = {
+  any: 'any',
   text: 'text',
   secret: 'secret',
   number: 'number',
@@ -41,6 +42,14 @@ const canCoercePrimitive = (
 }
 
 const comparePortDataTypes = (source: PortDataType, target: PortDataType): boolean => {
+  if (isPrimitive(target) && target.name === 'any') {
+    return true
+  }
+
+  if (isPrimitive(source) && source.name === 'any') {
+    return true
+  }
+
   if (isPrimitive(source) && isPrimitive(target)) {
     return canCoercePrimitive(source, target)
   }
@@ -94,6 +103,8 @@ export const inputSupportsManualValue = (input: InputPort): boolean =>
 export const runtimeInputTypeToPortDataType = (type: string): PortDataType => {
   const normalized = type.toLowerCase()
   switch (normalized) {
+    case 'any':
+      return { kind: 'primitive', name: 'any' }
     case 'text':
     case 'string':
       return { kind: 'primitive', name: 'text' }

--- a/packages/component-sdk/src/ports.ts
+++ b/packages/component-sdk/src/ports.ts
@@ -56,6 +56,10 @@ function json(options: PrimitiveOptions = {}): PrimitivePortType {
   return primitive('json', options);
 }
 
+function any(options: PrimitiveOptions = {}): PrimitivePortType {
+  return primitive('any', options);
+}
+
 function list(element: PrimitivePortType | ContractPortType): ListPortType {
   return {
     kind: 'list',
@@ -85,6 +89,7 @@ export const port = Object.freeze({
   secret,
   file,
   json,
+  any,
   list,
   map,
   contract,
@@ -165,6 +170,9 @@ function coercePrimitive(
     }
     case 'file':
     case 'json': {
+      return { ok: true, value };
+    }
+    case 'any': {
       return { ok: true, value };
     }
     default: {

--- a/packages/component-sdk/src/types.ts
+++ b/packages/component-sdk/src/types.ts
@@ -62,6 +62,7 @@ export interface LogEventInput {
 }
 
 export type PrimitivePortTypeName =
+  | 'any'
   | 'text'
   | 'secret'
   | 'number'

--- a/worker/src/components/core/console-log.ts
+++ b/worker/src/components/core/console-log.ts
@@ -58,7 +58,7 @@ const definition: ComponentDefinition<Input, Output> = {
       {
         id: 'data',
         label: 'Data',
-        dataType: port.json({ coerceFrom: ['text'] }),
+        dataType: port.any(),
         required: true,
         description: 'Any data to log (objects will be JSON stringified).',
       },


### PR DESCRIPTION
## Summary
- introduce an any primitive in the shared SDK and propagate it through backend and frontend schemas
- allow any ports to connect universally in port comparison helpers
- update console log component to accept any data without coercion

## Testing
- not run