### PR TITLE
fix(worker/shuffledns-massdns): run binary without shell; always pass -mode; normalise output

### DIFF
--- a/worker/src/components/index.ts
+++ b/worker/src/components/index.ts
@@ -26,6 +26,7 @@ import './security/dnsx';
 import './security/httpx';
 import './security/notify';
 import './security/prowler-scan';
+import './security/shuffledns-massdns';
 
 // IT Automation components
 import './it-automation/google-workspace-license-unassign';

--- a/worker/src/components/security/__tests__/shuffledns-massdns.test.ts
+++ b/worker/src/components/security/__tests__/shuffledns-massdns.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeAll, afterEach, vi } from 'bun:test';
+import * as sdk from '@shipsec/component-sdk';
+import { componentRegistry } from '../../index';
+import type { ShufflednsMassdnsInput, ShufflednsMassdnsOutput } from '../shuffledns-massdns';
+
+describe('shuffledns-massdns component', () => {
+  beforeAll(async () => {
+    await import('../../index');
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('registers with expected metadata', () => {
+    const component = componentRegistry.get<ShufflednsMassdnsInput, ShufflednsMassdnsOutput>(
+      'shipsec.shuffledns.massdns',
+    );
+    expect(component).toBeDefined();
+    expect(component!.label).toBe('Shuffledns + MassDNS');
+    expect(component!.category).toBe('security');
+    expect(component!.metadata?.slug).toBe('shuffledns-massdns');
+  });
+
+  it('normalises plain text output into subdomains array', async () => {
+    const component = componentRegistry.get<ShufflednsMassdnsInput, ShufflednsMassdnsOutput>(
+      'shipsec.shuffledns.massdns',
+    );
+    if (!component) throw new Error('Component not registered');
+
+    const context = sdk.createExecutionContext({ runId: 'run-1', componentRef: 'shuffledns-test' });
+
+    const params = component.inputSchema.parse({
+      domains: ['example.com'],
+      mode: 'bruteforce',
+      words: ['www', 'api', 'dev'],
+    });
+
+    vi.spyOn(sdk, 'runComponentWithRunner').mockResolvedValue(
+      'www.example.com\napi.example.com\napi.example.com\n',
+    );
+
+    const result = component.outputSchema.parse(await component.execute(params, context));
+    expect(result.domainCount).toBe(1);
+    // Deduped
+    expect(result.subdomains).toEqual(['www.example.com', 'api.example.com']);
+    expect(result.subdomainCount).toBe(2);
+  });
+
+  it('uses docker runner with correct image', () => {
+    const component = componentRegistry.get<ShufflednsMassdnsInput, ShufflednsMassdnsOutput>(
+      'shipsec.shuffledns.massdns',
+    );
+    if (!component) throw new Error('Component not registered');
+    expect(component.runner.kind).toBe('docker');
+    if (component.runner.kind === 'docker') {
+      expect(component.runner.image).toBe('ghcr.io/shipsecai/shuffledns-massdns:latest');
+      // We no longer depend on a shell entrypoint; the execute path sets
+      // the entrypoint to the tool binary and passes flags directly.
+      // The static runner definition just provides image/network defaults.
+      expect(component.runner.entrypoint).toBeUndefined();
+    }
+  });
+});

--- a/worker/src/components/security/shuffledns-massdns.ts
+++ b/worker/src/components/security/shuffledns-massdns.ts
@@ -1,0 +1,336 @@
+import { z } from 'zod';
+import {
+  componentRegistry,
+  ComponentDefinition,
+  port,
+  runComponentWithRunner,
+  type DockerRunnerConfig,
+} from '@shipsec/component-sdk';
+
+// Input schema for Shuffledns + MassDNS component
+const inputSchema = z
+  .object({
+    domains: z
+      .array(
+        z
+          .string()
+          .min(1)
+          .regex(/^[\w.-]+$/, 'Domains may only include letters, numbers, dots, underscores, and hyphens.'),
+      )
+      .min(1, 'Provide at least one domain.'),
+    mode: z
+      .enum(['bruteforce', 'resolve'])
+      .default('bruteforce')
+      .describe('Execution mode: bruteforce with a wordlist or resolve a list of seeds'),
+    words: z
+      .array(z.string().min(1))
+      .optional()
+      .describe('Wordlist entries for bruteforce mode'),
+    seeds: z
+      .array(z.string().min(1))
+      .optional()
+      .describe('Seed subdomains for resolve mode'),
+    resolvers: z
+      .array(
+        z
+          .string()
+          .min(1)
+          .regex(/^[\w.:+-]+$/, 'Resolver should be a hostname/IP, optionally with port (e.g. 1.1.1.1:53).'),
+      )
+      .default([]),
+    trustedResolvers: z
+      .array(
+        z
+          .string()
+          .min(1)
+          .regex(/^[\w.:+-]+$/, 'Resolver should be a hostname/IP, optionally with port (e.g. 1.1.1.1:53).'),
+      )
+      .default([]),
+    threads: z.number().int().positive().max(20000).optional().describe('Concurrent massdns resolves (-t)'),
+    retries: z.number().int().min(1).max(20).default(5).describe('Retries for DNS enumeration'),
+    wildcardStrict: z.boolean().default(false).describe('Strict wildcard checking (-sw)'),
+    wildcardThreads: z
+      .number()
+      .int()
+      .positive()
+      .max(2000)
+      .optional()
+      .describe('Concurrent wildcard checks (-wt)'),
+    massdnsCmd: z
+      .string()
+      .optional()
+      .describe("Optional massdns commands passed via '-mcmd' (e.g. '-i 10')"),
+  })
+  .refine(
+    (val) => (val.mode === 'bruteforce' ? Array.isArray(val.words) && val.words.length > 0 : true),
+    { message: 'words are required for bruteforce mode', path: ['words'] },
+  )
+  .refine(
+    (val) => (val.mode === 'resolve' ? Array.isArray(val.seeds) && val.seeds.length > 0 : true),
+    { message: 'seeds are required for resolve mode', path: ['seeds'] },
+  );
+
+type Input = z.infer<typeof inputSchema>;
+
+type Output = {
+  subdomains: string[];
+  rawOutput: string;
+  domainCount: number;
+  subdomainCount: number;
+};
+
+const outputSchema: z.ZodType<Output> = z.object({
+  subdomains: z.array(z.string()),
+  rawOutput: z.string(),
+  domainCount: z.number(),
+  subdomainCount: z.number(),
+});
+
+const definition: ComponentDefinition<Input, Output> = {
+  id: 'shipsec.shuffledns.massdns',
+  label: 'Shuffledns + MassDNS',
+  category: 'security',
+  runner: {
+    kind: 'docker',
+    image: 'ghcr.io/shipsecai/shuffledns-massdns:latest',
+    // Do not depend on a shell in the image; we'll run the binary directly
+    network: 'bridge',
+    timeoutSeconds: 300,
+    env: { HOME: '/root' },
+    // Placeholder; real command is built dynamically in execute()
+    command: ['--help'],
+  },
+  inputSchema,
+  outputSchema,
+  docs:
+    'Bruteforce or resolve subdomains using Shuffledns with MassDNS. Supports resolvers, trusted resolvers, thread control, retries, and wildcard handling.',
+  metadata: {
+    slug: 'shuffledns-massdns',
+    version: '1.0.0',
+    type: 'scan',
+    category: 'security',
+    description:
+      'High-performance subdomain bruteforce/resolve powered by Shuffledns and MassDNS. Accepts inline wordlists or seed lists and optional resolver tuning.',
+    documentation: 'ProjectDiscovery shuffledns with MassDNS backend. See https://github.com/projectdiscovery/shuffledns',
+    icon: 'Shuffle',
+    author: {
+      name: 'ShipSecAI',
+      type: 'shipsecai',
+    },
+    isLatest: true,
+    deprecated: false,
+    inputs: [
+      { id: 'domains', label: 'Target Domains', dataType: port.list(port.text()), required: true },
+      { id: 'words', label: 'Wordlist (bruteforce)', dataType: port.list(port.text()), required: false },
+      { id: 'seeds', label: 'Seeds (resolve)', dataType: port.list(port.text()), required: false },
+      { id: 'resolvers', label: 'Resolvers', dataType: port.list(port.text()), required: false },
+      { id: 'trustedResolvers', label: 'Trusted Resolvers', dataType: port.list(port.text()), required: false },
+    ],
+    outputs: [
+      { id: 'subdomains', label: 'Discovered Subdomains', dataType: port.list(port.text()) },
+      { id: 'rawOutput', label: 'Raw Output', dataType: port.text() },
+    ],
+    parameters: [
+      {
+        id: 'mode',
+        label: 'Mode',
+        type: 'select',
+        default: 'bruteforce',
+        description: 'Choose how shuffledns operates.',
+        options: [
+          { label: 'Bruteforce (with wordlist)', value: 'bruteforce' },
+          { label: 'Resolve (from seeds)', value: 'resolve' },
+        ],
+      },
+      { id: 'threads', label: 'Threads (-t)', type: 'number', min: 1, max: 20000 },
+      { id: 'retries', label: 'Retries', type: 'number', min: 1, max: 20, default: 5 },
+      { id: 'wildcardStrict', label: 'Strict Wildcard (-sw)', type: 'boolean', default: false },
+      { id: 'wildcardThreads', label: 'Wildcard Threads (-wt)', type: 'number', min: 1, max: 2000 },
+      { id: 'massdnsCmd', label: 'MassDNS Extra Cmd (-mcmd)', type: 'text' },
+    ],
+  },
+  async execute(input, context) {
+    const { domains, mode } = input;
+    const modeText = mode ?? 'bruteforce';
+    context.logger.info(
+      `[Shuffledns] ${modeText} ${domains.length} domain(s) via Shuffledns + MassDNS`,
+    );
+    context.emitProgress(
+      `Running shuffledns (${modeText}) for ${domains.length} domain${domains.length > 1 ? 's' : ''}`,
+    );
+
+    // Build command flags in TypeScript
+    const flags: string[] = ['-silent'];
+    for (const d of domains) {
+      flags.push('-d', d);
+    }
+
+    // Prepare optional list contents via env to keep shell minimal
+    const env: Record<string, string> = {};
+    const mkB64 = (lines?: string[]) =>
+      Array.isArray(lines) && lines.length > 0
+        ? Buffer.from(lines.map((s) => s.trim()).filter(Boolean).join('\n'), 'utf8').toString('base64')
+        : '';
+
+    // Always specify execution mode explicitly for the image
+    flags.push('-mode', modeText);
+
+    if (modeText === 'bruteforce') {
+      const wordsB64 = mkB64(input.words);
+      if (wordsB64) env['WORDS_B64'] = wordsB64;
+    } else if (modeText === 'resolve') {
+      const seedsB64 = mkB64(input.seeds);
+      if (seedsB64) env['SEEDS_B64'] = seedsB64;
+    }
+
+    const resolversB64 = mkB64(input.resolvers);
+    const trustedB64 = mkB64(input.trustedResolvers);
+    if (resolversB64) env['RESOLVERS_B64'] = resolversB64;
+    if (trustedB64) env['TRUSTED_B64'] = trustedB64;
+
+    if (typeof input.threads === 'number' && input.threads > 0) {
+      flags.push('-t', String(input.threads));
+    }
+    if (typeof input.retries === 'number' && input.retries > 0) {
+      flags.push('-retries', String(input.retries));
+    }
+    if (input.wildcardStrict) {
+      flags.push('-sw');
+    }
+    if (typeof input.wildcardThreads === 'number' && input.wildcardThreads > 0) {
+      flags.push('-wt', String(input.wildcardThreads));
+    }
+    if (input.massdnsCmd && input.massdnsCmd.trim().length > 0) {
+      // Keep quotes around the value when passing to CLI
+      flags.push('-mcmd', input.massdnsCmd.trim());
+    }
+
+    // Write any provided lists to host temp dir and mount into the container.
+    // This avoids requiring a shell inside the image.
+    const fs = await import('node:fs/promises');
+    const os = await import('node:os');
+    const path = await import('node:path');
+
+    const hostInputDir = await fs.mkdtemp(path.join(os.tmpdir(), 'shuffledns-input-'));
+    const WORDS = '/input/words.txt';
+    const SEEDS = '/input/seeds.txt';
+    const RESOLVERS = '/input/resolvers.txt';
+    const TRUSTED = '/input/trusted.txt';
+
+    const writeIfAny = async (values: string[] | undefined, file: string) => {
+      if (Array.isArray(values) && values.length > 0) {
+        const contents = values.map((s) => s.trim()).filter(Boolean).join('\n');
+        await fs.writeFile(path.join(hostInputDir, path.basename(file)), contents, 'utf8');
+        return true;
+      }
+      return false;
+    };
+
+    const wroteWords = await writeIfAny(input.words, WORDS);
+    const wroteSeeds = await writeIfAny(input.seeds, SEEDS);
+    const wroteResolvers = await writeIfAny(input.resolvers, RESOLVERS);
+    const wroteTrusted = await writeIfAny(input.trustedResolvers, TRUSTED);
+
+    // Attach file flags if present
+    if (wroteWords) {
+      flags.push('-w', WORDS);
+    }
+    if (wroteSeeds) {
+      flags.push('-list', SEEDS);
+    }
+    if (wroteResolvers) {
+      flags.push('-r', RESOLVERS);
+    }
+    if (wroteTrusted) {
+      flags.push('-tr', TRUSTED);
+    }
+
+    const baseRunner = definition.runner;
+    if (baseRunner.kind !== 'docker') {
+      throw new Error('Shuffledns runner must be docker');
+    }
+
+    const runnerConfig: DockerRunnerConfig = {
+      kind: 'docker',
+      image: baseRunner.image,
+      network: baseRunner.network,
+      timeoutSeconds: baseRunner.timeoutSeconds,
+      env: { ...(baseRunner.env ?? {}), ...env },
+      // Run the binary directly; pass flags as the command args
+      entrypoint: 'shuffledns',
+      command: flags,
+      volumes: [
+        { source: hostInputDir, target: '/input', readOnly: true },
+      ],
+    };
+
+    let resultUnknown: unknown;
+    try {
+      resultUnknown = (await runComponentWithRunner(
+        runnerConfig,
+        async () => ({} as Output),
+        input,
+        context,
+      )) as unknown;
+    } finally {
+      try {
+        await fs.rm(hostInputDir, { recursive: true, force: true });
+      } catch {}
+    }
+
+    // Shuffledns with -silent prints hostnames (plain text). Normalise string output.
+    if (typeof resultUnknown === 'string') {
+      const rawOutput = resultUnknown;
+      const subdomains = rawOutput
+        .split(/\r?\n/g)
+        .map((line) => line.trim())
+        .filter((line) => line.length > 0);
+
+      const deduped = Array.from(new Set(subdomains));
+
+      return outputSchema.parse({
+        subdomains: deduped,
+        rawOutput,
+        domainCount: input.domains.length,
+        subdomainCount: deduped.length,
+      });
+    }
+
+    // If container returned an object (e.g., JSON), try to validate/normalise
+    if (resultUnknown && typeof resultUnknown === 'object') {
+      const parsed = outputSchema.safeParse(resultUnknown);
+      if (parsed.success) {
+        return parsed.data;
+      }
+
+      const maybeRaw = 'rawOutput' in (resultUnknown as any) ? String((resultUnknown as any).rawOutput ?? '') : '';
+      const subdomainsValue = Array.isArray((resultUnknown as any).subdomains)
+        ? ((resultUnknown as any).subdomains as unknown[])
+            .map((v) => (typeof v === 'string' ? v.trim() : String(v)))
+            .filter((v) => v.length > 0)
+        : maybeRaw
+            .split(/\r?\n/g)
+            .map((line) => line.trim())
+            .filter((line) => line.length > 0);
+
+      return outputSchema.parse({
+        subdomains: Array.from(new Set(subdomainsValue)),
+        rawOutput: maybeRaw || subdomainsValue.join('\n'),
+        domainCount: input.domains.length,
+        subdomainCount: subdomainsValue.length,
+      });
+    }
+
+    // Fallback – empty
+    return outputSchema.parse({
+      subdomains: [],
+      rawOutput: '',
+      domainCount: input.domains.length,
+      subdomainCount: 0,
+    });
+  },
+};
+
+componentRegistry.register(definition);
+
+export type { Input as ShufflednsMassdnsInput, Output as ShufflednsMassdnsOutput };

--- a/worker/src/temporal/activities/run-component.activity.ts
+++ b/worker/src/temporal/activities/run-component.activity.ts
@@ -152,12 +152,11 @@ export async function runComponentActivity(
   });
 
   try {
-    const output = await runComponentWithRunner(
-      component.runner,
-      component.execute,
-      parsedParams,
-      context,
-    );
+    // Execute the component logic directly so that any
+    // normalisation/parsing inside `execute` runs.
+    // Docker/remote execution should be invoked from within
+    // the component via `runComponentWithRunner`.
+    const output = await component.execute(parsedParams, context);
 
     trace?.record({
       type: 'NODE_COMPLETED',


### PR DESCRIPTION
fix(worker/shuffledns-massdns): run binary directly, mount inputs; always pass -mode; normalise output in activity runner

Summary
- Shuffledns container crashed previously due to missing /bin/sh and missing -mode. This PR removes the shell dependency and always passes mode.
- The activity runner now calls component.execute() so component-level normalisation/parsing runs and downstream nodes receive the expected structured outputs.
- UI: expose Mode as a select with two options (Bruteforce, Resolve) to prevent free-text input.

Why
- Error seen: `exec: "sh": executable file not found in $PATH` when the image lacked a shell.
- Error seen: `[FTL] Program exiting: execution mode not specified` when mode wasn’t explicitly provided.
- Downstream mapping showed `Input 'data' ... was undefined` because the raw string output bypassed component.execute normalisation.

Changes
- worker/src/components/security/shuffledns-massdns.ts
  - Drop shell entrypoint from runner; build command entirely in TS.
  - Write words/seeds/resolvers/trusted to host temp dir and mount at /input.
  - Run `shuffledns` binary directly with flags; always add `-mode <bruteforce|resolve>`.
  - Parse and dedupe plain-text output, return { subdomains, rawOutput, domainCount, subdomainCount }.
  - UI metadata: Mode as select with two options.
- worker/src/temporal/activities/run-component.activity.ts
  - Execute via `component.execute()` so each component controls its own Docker call and output normalisation.
- worker/src/components/index.ts
  - Register shuffledns-massdns component.
- worker/src/components/security/__tests__/shuffledns-massdns.test.ts
  - Add tests for registration and output normalisation; adjust runner expectations.

Behaviour changes
- Mode is required explicitly; default remains bruteforce. Resolve mode requires seeds, bruteforce requires words (validated by schema).
- Docker runs the tool binary directly; no reliance on a shell inside the image.

Validation
- Worker unit tests: `bun --cwd worker test` (pass on local).
- Typecheck: `bun --cwd worker typecheck` (pass).
- Smoke checks:
  - `docker run --rm --entrypoint shuffledns ghcr.io/shipsecai/shuffledns-massdns:latest -h` (binary present)
  - End-to-end: run a workflow with shuffledns → console log shows subdomains array; no undefined input warnings.

Risks / Considerations
- Binary name/path must match `shuffledns`. If image layout differs, update entrypoint accordingly.
- We mount host temp dir read-only at `/input`; ensure Docker has permission to read those files.
- Activity runner change makes components responsible for invoking their runner within execute. Other components already follow this pattern.

Follow-ups
- Add a small smoke script similar to subfinder’s for shuffledns.
- Optionally wire resolvers/trusted from workspace settings.

Checklist
- [x] Worker tests pass locally
- [x] Typecheck passes
- [ ] Monorepo lint/test not run here (can run in CI)
- [ ] Docs: add a note about Mode parameter in `.ai/component-sdk.md` (optional)
