### PR TITLE
fix: stabilize run cache selectors

### DIFF
--- a/frontend/src/components/timeline/ExecutionInspector.tsx
+++ b/frontend/src/components/timeline/ExecutionInspector.tsx
@@ -68,7 +68,8 @@ export function ExecutionInspector({ onRerunRun }: ExecutionInspectorProps = {})
     (state) => state.metadata
   )
   const workflowCacheKey = workflowId ?? '__global__'
-  const runs = useRunStore((state) => state.cache[workflowCacheKey]?.runs ?? [])
+  const scopedRuns = useRunStore((state) => state.cache[workflowCacheKey]?.runs)
+  const runs = scopedRuns ?? []
   const { logs } = useExecutionStore()
   const { inspectorTab, setInspectorTab } = useWorkflowUiStore()
   const fetchRunArtifacts = useArtifactStore((state) => state.fetchRunArtifacts)

--- a/frontend/src/components/timeline/ReviewInspector.tsx
+++ b/frontend/src/components/timeline/ReviewInspector.tsx
@@ -26,7 +26,8 @@ export function ReviewInspector() {
   } = useExecutionTimelineStore()
   const { id: workflowId } = useWorkflowStore((state) => state.metadata)
   const workflowCacheKey = workflowId ?? '__global__'
-  const runs = useRunStore((state) => state.cache[workflowCacheKey]?.runs ?? [])
+  const scopedRuns = useRunStore((state) => state.cache[workflowCacheKey]?.runs)
+  const runs = scopedRuns ?? []
   const { logs } = useExecutionStore()
   const { inspectorTab, setInspectorTab } = useWorkflowUiStore()
 

--- a/frontend/src/components/timeline/RunSelector.tsx
+++ b/frontend/src/components/timeline/RunSelector.tsx
@@ -68,9 +68,11 @@ export function RunSelector({ onRerun }: RunSelectorProps = {}) {
     (state) => state.metadata
   )
   const workflowCacheKey = workflowId ?? '__global__'
-  const runs = useRunStore((state) => state.cache[workflowCacheKey]?.runs ?? [])
+  const scopedRuns = useRunStore((state) => state.cache[workflowCacheKey]?.runs)
+  const runs = scopedRuns ?? []
   const fetchRuns = useRunStore((state) => state.fetchRuns)
-  const isLoadingRuns = useRunStore((state) => state.cache[workflowCacheKey]?.isLoading ?? false)
+  const isLoadingRuns =
+    useRunStore((state) => state.cache[workflowCacheKey]?.isLoading) ?? false
 
   const {
     runId: currentLiveRunId,

--- a/frontend/src/pages/WorkflowBuilder.tsx
+++ b/frontend/src/pages/WorkflowBuilder.tsx
@@ -85,7 +85,8 @@ function WorkflowBuilderContent() {
   const selectedRunId = useExecutionTimelineStore((state) => state.selectedRunId)
   const fetchRuns = useRunStore((state) => state.fetchRuns)
   const workflowCacheKey = metadata.id ?? '__global__'
-  const runs = useRunStore((state) => state.cache[workflowCacheKey]?.runs ?? [])
+  const scopedRuns = useRunStore((state) => state.cache[workflowCacheKey]?.runs)
+  const runs = scopedRuns ?? []
   const { toast } = useToast()
   const layoutRef = useRef<HTMLDivElement | null>(null)
   const inspectorResizingRef = useRef(false)


### PR DESCRIPTION
## Summary
- avoid infinite render loops by making run store selectors return stable references
- update RunSelector, ExecutionInspector, ReviewInspector, and WorkflowBuilder to read the cached array once and default outside the selector

## Testing
- Manual: reloaded workflow builder to confirm RunSelector renders without the maximum update depth error