### PR TITLE
feat: add GitHub app webhook demo and trigger UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,12 @@ VITE_PUBLIC_POSTHOG_KEY=phc_...
 VITE_PUBLIC_POSTHOG_HOST=https://us.i.posthog.com
 ```
 
+GitHub App (for PR webhooks/checks):
+
+- Backend: set `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_APP_WEBHOOK_SECRET`.
+- Frontend: set `VITE_GITHUB_APP_INSTALL_URL` to your app’s install link (enables the “Install GitHub App” button in Connections).
+- Point your GitHub App webhook to `http://localhost:3211/api/v1/webhooks/github/app` (or your deployed host). The OAuth “Connect GitHub” remains user-scoped; the App is required for PR triggers.
+
 ### 3. Bring up the shared infrastructure
 
 ```bash

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -38,6 +38,11 @@ AUTH_LOCAL_API_KEY=""
 CLERK_PUBLISHABLE_KEY=""
 CLERK_SECRET_KEY=""
 
+# GitHub App (webhooks + repo-scoped tokens)
+GITHUB_APP_ID=""
+GITHUB_APP_PRIVATE_KEY=""        # PEM, keep quoted if multi-line
+GITHUB_APP_WEBHOOK_SECRET=""     # Matches the App's webhook secret
+
 # Platform service account (optional, used for auth enrichment + workflow linkage)
 PLATFORM_API_URL=""
 PLATFORM_SERVICE_TOKEN=""

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -5,6 +5,7 @@ import { ConfigModule } from '@nestjs/config';
 import { AppController } from './app.controller';
 import { AppService } from './app.service';
 import { authConfig } from './config/auth.config';
+import { githubAppConfig } from './config/github-app.config';
 import { AuthModule } from './auth/auth.module';
 import { AuthGuard } from './auth/auth.guard';
 import { RolesGuard } from './auth/roles.guard';
@@ -15,6 +16,7 @@ import { TraceModule } from './trace/trace.module';
 import { WorkflowsModule } from './workflows/workflows.module';
 import { TestingSupportModule } from './testing/testing.module';
 import { IntegrationsModule } from './integrations/integrations.module';
+import { GithubModule } from './github/github.module';
 
 const coreModules = [
   AuthModule,
@@ -24,6 +26,7 @@ const coreModules = [
   StorageModule,
   SecretsModule,
   IntegrationsModule,
+  GithubModule,
 ];
 const testingModules =
   process.env.NODE_ENV === 'production' ? [] : [TestingSupportModule];
@@ -33,7 +36,7 @@ const testingModules =
     ConfigModule.forRoot({
       isGlobal: true,
       envFilePath: ['.env', '../.env'],
-      load: [authConfig],
+      load: [authConfig, githubAppConfig],
     }),
     ...coreModules,
     ...testingModules,

--- a/backend/src/auth/auth.guard.ts
+++ b/backend/src/auth/auth.guard.ts
@@ -22,6 +22,11 @@ export class AuthGuard implements CanActivate {
           return true;
         }
 
+        // Allow unauthenticated GitHub webhooks (signature is verified separately)
+        if (request.path?.startsWith('/api/v1/webhooks/github')) {
+          return true;
+        }
+
         this.logger.log(
           `[AUTH] Guard activating for ${request.method} ${request.path} - Provider: ${this.authService.providerName}`
         );

--- a/backend/src/config/github-app.config.ts
+++ b/backend/src/config/github-app.config.ts
@@ -1,0 +1,21 @@
+import { registerAs } from '@nestjs/config';
+
+export interface GithubAppConfig {
+  appId: number | null;
+  privateKey: string | null;
+  webhookSecret: string | null;
+}
+
+function parseAppId(raw: string | undefined): number | null {
+  if (!raw) {
+    return null;
+  }
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export const githubAppConfig = registerAs<GithubAppConfig>('githubApp', () => ({
+  appId: parseAppId(process.env.GITHUB_APP_ID),
+  privateKey: process.env.GITHUB_APP_PRIVATE_KEY ?? null,
+  webhookSecret: process.env.GITHUB_APP_WEBHOOK_SECRET ?? null,
+}));

--- a/backend/src/github/github-dispatch.service.ts
+++ b/backend/src/github/github-dispatch.service.ts
@@ -1,0 +1,47 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import type { GithubEventEnvelope } from './github.types';
+import { TemporalService } from '../temporal/temporal.service';
+
+@Injectable()
+export class GithubDispatchService {
+  private readonly logger = new Logger(GithubDispatchService.name);
+  private readonly seen = new Set<string>();
+
+  constructor(private readonly temporal: TemporalService) {}
+
+  async dispatch(event: GithubEventEnvelope): Promise<void> {
+    if (!event.pullRequest?.head.sha) {
+      this.logger.warn(
+        `[Dispatch] Skipping event without PR head SHA (delivery=${event.deliveryId}, repo=${event.repository.fullName})`,
+      );
+      return;
+    }
+
+    if (this.seen.has(event.dedupeKey)) {
+      this.logger.log(
+        `[Dispatch] Duplicate delivery ignored (dedupe=${event.dedupeKey}, repo=${event.repository.fullName})`,
+      );
+      return;
+    }
+
+    this.seen.add(event.dedupeKey);
+
+    this.logger.log(
+      `[Dispatch] Ready to enqueue GitHub PR event (repo=${event.repository.fullName}, pr=#${event.pullRequest.number}, head=${event.pullRequest.head.sha}, dedupe=${event.dedupeKey})`,
+    );
+
+    // Quick demo: start minimal workflow carrying the envelope as args.
+    const workflowId = `github-demo-${event.dedupeKey}`.slice(0, 64);
+    await this.temporal.startWorkflow({
+      workflowType: 'minimalWorkflow',
+      workflowId,
+      args: [event],
+      memo: {
+        source: 'github-demo',
+        repo: event.repository.fullName,
+        delivery: event.deliveryId,
+      },
+    });
+  }
+}

--- a/backend/src/github/github-webhook.controller.ts
+++ b/backend/src/github/github-webhook.controller.ts
@@ -1,0 +1,62 @@
+import {
+  Body,
+  Controller,
+  Headers,
+  HttpCode,
+  Logger,
+  Post,
+  Req,
+  UnauthorizedException,
+} from '@nestjs/common';
+import type { RawBodyRequest } from '@nestjs/common';
+import type { Request } from 'express';
+
+import { GithubAppService } from './github.service';
+import { GithubWebhookService } from './github-webhook.service';
+
+@Controller('webhooks/github')
+export class GithubWebhookController {
+  private readonly logger = new Logger(GithubWebhookController.name);
+
+  constructor(
+    private readonly githubApp: GithubAppService,
+    private readonly webhookService: GithubWebhookService,
+  ) {}
+
+  @Post('app')
+  @HttpCode(202)
+  async handleGithubAppWebhook(
+    @Req() req: RawBodyRequest<Request>,
+    @Body() body: any,
+    @Headers('x-github-event') eventName: string | undefined,
+    @Headers('x-github-delivery') deliveryId: string | undefined,
+    @Headers('x-hub-signature-256') signature: string | undefined,
+    @Headers('user-agent') userAgent: string | undefined,
+  ): Promise<{ ok: true }> {
+    const rawBody =
+      (req as any).rawBody ??
+      Buffer.from(typeof body === 'string' ? body : JSON.stringify(body ?? {}), 'utf8');
+
+    if (!this.githubApp.verifySignature(rawBody, signature)) {
+      throw new UnauthorizedException('Invalid GitHub webhook signature');
+    }
+
+    const normalizedBody = typeof body === 'string' ? JSON.parse(body) : body ?? {};
+    const event = eventName ?? 'unknown';
+    const delivery = deliveryId ?? 'missing-delivery-id';
+
+    if (userAgent !== undefined) {
+      this.logger.debug(`GitHub webhook user-agent: ${userAgent}`);
+    }
+
+    const envelope = this.webhookService.normalizePayload(normalizedBody, {
+      event,
+      deliveryId: delivery,
+      signature,
+    });
+
+    await this.webhookService.handleWebhook(envelope);
+
+    return { ok: true };
+  }
+}

--- a/backend/src/github/github-webhook.service.ts
+++ b/backend/src/github/github-webhook.service.ts
@@ -1,0 +1,104 @@
+import { Injectable, Logger } from '@nestjs/common';
+
+import type { GithubEventEnvelope, GithubPullRequestInfo, GithubRepositoryInfo } from './github.types';
+import { GithubDispatchService } from './github-dispatch.service';
+
+interface NormalizeResult extends GithubEventEnvelope {}
+
+@Injectable()
+export class GithubWebhookService {
+  private readonly logger = new Logger(GithubWebhookService.name);
+
+  constructor(private readonly dispatch: GithubDispatchService) {}
+
+  async handleWebhook(envelope: GithubEventEnvelope): Promise<void> {
+    this.logger.log(
+      `[GitHub] ${envelope.event} delivery=${envelope.deliveryId} repo=${envelope.repository.fullName}`,
+    );
+
+    if (envelope.pullRequest?.head.sha) {
+      this.logger.debug(
+        `[GitHub] PR #${envelope.pullRequest.number} head=${envelope.pullRequest.head.sha} dedupe=${envelope.dedupeKey}`,
+      );
+    }
+
+    await this.dispatch.dispatch(envelope);
+  }
+
+  normalizePayload(
+    payload: any,
+    metadata: { event: string; deliveryId: string; signature: string | undefined },
+  ): NormalizeResult {
+    const repo = this.extractRepo(payload);
+    const pr = this.extractPullRequest(payload);
+
+    const headSha = pr?.head.sha ?? 'no-sha';
+    const dedupeKey = `${metadata.deliveryId}:${headSha}`;
+
+    return {
+      event: metadata.event,
+      deliveryId: metadata.deliveryId,
+      installationId: payload?.installation?.id ?? null,
+      repository: repo,
+      pullRequest: pr,
+      dedupeKey,
+      rawPayload: payload,
+    };
+  }
+
+  private extractRepo(payload: any): GithubRepositoryInfo {
+    const fullName: string =
+      payload?.repository?.full_name ??
+      [payload?.repository?.owner?.login, payload?.repository?.name]
+        .filter(Boolean)
+        .join('/') ??
+      'unknown/unknown';
+
+    const [owner, name] = fullName.split('/');
+
+    return {
+      owner: owner ?? 'unknown',
+      name: name ?? 'unknown',
+      fullName,
+    };
+  }
+
+  private extractPullRequest(payload: any): GithubPullRequestInfo | null {
+    const pr = payload?.pull_request;
+    if (!pr) {
+      return null;
+    }
+
+    const labels: string[] =
+      Array.isArray(pr.labels) && pr.labels.length > 0
+        ? pr.labels.map((label: any) => label?.name).filter(Boolean)
+        : [];
+
+    const headRepoFullName =
+      pr.head?.repo?.full_name ??
+      [pr.head?.repo?.owner?.login, pr.head?.repo?.name].filter(Boolean).join('/') ??
+      null;
+    const baseRepoFullName =
+      pr.base?.repo?.full_name ??
+      [pr.base?.repo?.owner?.login, pr.base?.repo?.name].filter(Boolean).join('/') ??
+      null;
+
+    return {
+      number: pr.number ?? -1,
+      head: {
+        sha: pr.head?.sha ?? null,
+        ref: pr.head?.ref ?? null,
+        repoFullName: headRepoFullName,
+        repoOwner: pr.head?.repo?.owner?.login ?? null,
+      },
+      base: {
+        sha: pr.base?.sha ?? null,
+        ref: pr.base?.ref ?? null,
+        repoFullName: baseRepoFullName,
+        repoOwner: pr.base?.repo?.owner?.login ?? null,
+      },
+      author: pr.user?.login ?? null,
+      labels,
+    };
+  }
+}

--- a/backend/src/github/github.module.ts
+++ b/backend/src/github/github.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+
+import { githubAppConfig } from '../config/github-app.config';
+import { GithubAppService } from './github.service';
+import { GithubWebhookController } from './github-webhook.controller';
+import { GithubWebhookService } from './github-webhook.service';
+import { GithubDispatchService } from './github-dispatch.service';
+import { TemporalModule } from '../temporal/temporal.module';
+
+@Module({
+  imports: [ConfigModule.forFeature(githubAppConfig), TemporalModule],
+  controllers: [GithubWebhookController],
+  providers: [GithubAppService, GithubWebhookService, GithubDispatchService],
+  exports: [GithubAppService, GithubWebhookService, GithubDispatchService],
+})
+export class GithubModule {}

--- a/backend/src/github/github.service.ts
+++ b/backend/src/github/github.service.ts
@@ -1,0 +1,45 @@
+import { Injectable, Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { createHmac, timingSafeEqual } from 'node:crypto';
+
+import type { GithubAppConfig } from '../config/github-app.config';
+
+@Injectable()
+export class GithubAppService {
+  private readonly logger = new Logger(GithubAppService.name);
+
+  constructor(private readonly configService: ConfigService) {}
+
+  private get config(): GithubAppConfig {
+    return this.configService.get<GithubAppConfig>('githubApp') ?? {
+      appId: null,
+      privateKey: null,
+      webhookSecret: null,
+    };
+  }
+
+  verifySignature(payload: Buffer | string, signatureHeader: string | undefined): boolean {
+    const secret = this.config.webhookSecret;
+
+    if (!secret) {
+      this.logger.warn('GitHub webhook secret is not configured; skipping signature verification');
+      return true;
+    }
+
+    if (!signatureHeader || !signatureHeader.startsWith('sha256=')) {
+      this.logger.warn('Missing or malformed X-Hub-Signature-256 header');
+      return false;
+    }
+
+    const expected = this.signPayload(payload, secret);
+    const received = Buffer.from(signatureHeader.replace('sha256=', ''), 'hex');
+
+    return received.length === expected.length && timingSafeEqual(received, expected);
+  }
+
+  private signPayload(payload: Buffer | string, secret: string): Buffer {
+    const hmac = createHmac('sha256', secret);
+    hmac.update(payload);
+    return hmac.digest();
+  }
+}

--- a/backend/src/github/github.types.ts
+++ b/backend/src/github/github.types.ts
@@ -1,0 +1,30 @@
+export interface GithubRepositoryInfo {
+  owner: string;
+  name: string;
+  fullName: string;
+}
+
+export interface GithubRefInfo {
+  sha: string | null;
+  ref: string | null;
+  repoFullName?: string | null;
+  repoOwner?: string | null;
+}
+
+export interface GithubPullRequestInfo {
+  number: number;
+  head: GithubRefInfo;
+  base: GithubRefInfo;
+  author: string | null;
+  labels: string[];
+}
+
+export interface GithubEventEnvelope {
+  event: string;
+  deliveryId: string;
+  installationId: number | null;
+  repository: GithubRepositoryInfo;
+  pullRequest: GithubPullRequestInfo | null;
+  dedupeKey: string;
+  rawPayload: unknown;
+}

--- a/backend/src/main.ts
+++ b/backend/src/main.ts
@@ -3,6 +3,7 @@ import 'reflect-metadata';
 import { NestFactory } from '@nestjs/core';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { cleanupOpenApiDoc } from 'nestjs-zod';
+import { json } from 'express';
 
 import { AppModule } from './app.module';
 
@@ -13,6 +14,16 @@ async function bootstrap() {
 
   // Set global prefix for all routes
   app.setGlobalPrefix('api/v1');
+
+  // Preserve raw body for GitHub webhook signature verification while still parsing JSON
+  app.use(
+    '/api/v1/webhooks/github',
+    json({
+      verify: (req: any, _res, buf) => {
+        req.rawBody = buf;
+      },
+    }),
+  );
 
   const httpAdapter = app.getHttpAdapter().getInstance();
   if (httpAdapter?.set) {

--- a/docker/docker-compose.full.yml
+++ b/docker/docker-compose.full.yml
@@ -136,6 +136,9 @@ services:
       - AUTH_PROVIDER=local
       - CLERK_PUBLISHABLE_KEY=
       - CLERK_SECRET_KEY=
+      - GITHUB_APP_ID=${GITHUB_APP_ID:-}
+      - GITHUB_APP_PRIVATE_KEY=${GITHUB_APP_PRIVATE_KEY:-}
+      - GITHUB_APP_WEBHOOK_SECRET=${GITHUB_APP_WEBHOOK_SECRET:-}
     ports:
       - "3211:3211"
     depends_on:
@@ -158,6 +161,7 @@ services:
         VITE_AUTH_PROVIDER: ${VITE_AUTH_PROVIDER:-local}
         VITE_DEFAULT_ORG_ID: ${VITE_DEFAULT_ORG_ID:-local-dev}
         VITE_CLERK_PUBLISHABLE_KEY: ${VITE_CLERK_PUBLISHABLE_KEY:-}
+        VITE_GITHUB_APP_INSTALL_URL: ${VITE_GITHUB_APP_INSTALL_URL:-}
     container_name: shipsec-frontend
     environment:
       - VITE_API_URL=http://localhost:3211
@@ -169,6 +173,7 @@ services:
       # If unset, the app disables analytics at runtime.
       - VITE_PUBLIC_POSTHOG_KEY=${VITE_PUBLIC_POSTHOG_KEY:-}
       - VITE_PUBLIC_POSTHOG_HOST=${VITE_PUBLIC_POSTHOG_HOST:-}
+      - VITE_GITHUB_APP_INSTALL_URL=${VITE_GITHUB_APP_INSTALL_URL:-}
     ports:
       - "8090:8080"
     depends_on:

--- a/docs/github-pr-workflow-plan.md
+++ b/docs/github-pr-workflow-plan.md
@@ -1,0 +1,101 @@
+# GitHub PR Workflow Trigger Plan
+
+## Decision
+- Use a GitHub App for PR-triggered automation and GitHub feedback (checks/statuses/comments).
+- Keep the existing GitHub OAuth provider for optional user-scoped actions (impersonated comments, manual reruns), but it is not sufficient alone because it cannot receive webhooks or issue repo-scoped installation tokens.
+
+## GitHub-facing experience
+- Installable app: minimal permissions (`Metadata: read`, `Contents: read`, `Pull requests: read & write`, `Checks: write`, `Commit statuses: write`; optionally `Actions: read` for workflow file lookups). Webhook events: `pull_request` (opened, synchronize, reopened, ready_for_review), `pull_request_review`, `pull_request_review_comment`, `check_run`/`check_suite`; `push` to default branch if we want post-merge runs.
+- Repo-local config: `.shipsec/workflows.yml` per repo with simple mapping to Studio workflows and filters. Example:
+  ```yaml
+  workflows:
+    - on: pull_request.opened|synchronize
+      workflow: shipsec-run-pr-sast
+      filters:
+        paths: ["src/**"]
+      checks:
+        block: false  # report-only by default
+  ```
+  Default behavior: if the file is absent, run a safe default workflow (e.g., PR hygiene + SAST) to avoid setup friction.
+- UX: Connections page shows “Install GitHub App” CTA, installation status by repo/org, and last webhook receipt. Provide copy/paste webhook secret and app installation link.
+
+## Central workflow brain in ShipSec Studio
+- Webhook ingestion: single endpoint verifies `X-Hub-Signature-256`, maps installation id to workspace, and enqueues the event (no heavy work in the handler).
+- Event normalization: produce a standard envelope with repo/owner, installation id, PR number, head/base SHA+branch, author, labels, touched files summary (lazy-loaded via app token), and dedupe key (`delivery id` + `head sha`).
+- Dispatch: select workflow(s) from repo config (or default), start `shipsec-run-*` with inputs (commit, branch, files, author). Use idempotent run keys and per-repo concurrency guards to avoid double execution.
+- GitHub feedback: create/update a `check_run` per workflow. Optional PR comment summarizing findings; keep non-blocking until policy toggles exist. Store links back to Studio run detail.
+- Auth layering: use app installation tokens for automation; overlay a stored user OAuth token only when we need impersonated comments or elevated scopes.
+- Observability & ops: log event→run mapping, emit metrics for queue/wait/run times, alert on webhook failures, and support redelivery replay. Keep run artifacts in existing storage and surface them in Studio.
+
+## Milestones (keep it simple)
+- M1: Create GitHub App, webhook endpoint with signature verification, enqueue PR opened/synchronize events, post a minimal check_run to prove the loop.
+- M2: Implement repo config parsing, dispatch into the workflow engine, update checks on success/failure, and add idempotency/rate limiting.
+- M3: UX polish (Connections card, install status, per-repo enable/disable), run history linking, and short docs for installation + sample configs.
+
+## How it works end-to-end
+1) Install + config (optional): Customer installs the ShipSec GitHub App on repos/orgs. If they add `.shipsec/workflows.yml`, it overrides defaults; otherwise we run the safe default workflow.  
+2) Webhook in: GitHub sends `pull_request` (and related) events to our signed endpoint. We verify `X-Hub-Signature-256`, map installation → workspace, and enqueue the event (handler stays thin).  
+3) Enrich + select: A worker pulls the event, fetches `.shipsec/workflows.yml` from the repo using the app token (falls back to default), and expands a standard envelope (repo, PR, head/base, files touched, author, labels, dedupe key). Matching workflows are selected based on event type and filters.  
+4) Run workflows: For each selected entry, we start a `shipsec-run-*` workflow with an idempotent key (installation + repo + head SHA + workflow name) and per-repo concurrency guard. Activities pull code/context via the app token; optional user OAuth is only for impersonated actions.  
+5) Report to GitHub: We open/update a `check_run` per workflow (queued → running → success/failure). Optional PR comment summarizes findings and links back to the Studio run detail. Blocking stays off until policy toggles are set.  
+6) Observe + recover: We log event→run mapping, emit metrics (queue, start, finish), and keep artifacts/logs in Studio. Webhook redeliveries dedupe via delivery id + head SHA.
+
+## Quick answers
+- One app per org: A single GitHub App installation at the org level covers all selected repos; we do not need per-repo apps.  
+- Webhook endpoint: Yes—our backend exposes one signed webhook endpoint for the app. It only verifies, maps, and enqueues; workers do the heavier work.  
+- Repo config optional: `.shipsec/workflows.yml` is only needed for overrides; absence falls back to the default safe workflow.  
+
+## GitHub trigger (no-code canvas)
+- The webhook is the transport, but the canvas shows an explicit **GitHub PR Trigger** node (like Manual Trigger) so runs are clearly marked as GitHub-initiated.  
+- The trigger node supplies event metadata (repo, PR number, head/base, author, labels, file list) into downstream nodes.  
+- Typical chain: `[GitHub PR Trigger] → [Fetch repository snapshot] → [Component (e.g., trufflehog)] → [Summarize/format] → [Publish to GitHub checks/comments]`. The fetch step can be hidden/automatic; the trigger node remains visible for clarity and auditing.  
+
+## Implementation plan (lean)
+1) Backend (GitHub App + webhook)
+   - Add config for `GITHUB_APP_ID`, `GITHUB_APP_PRIVATE_KEY`, `GITHUB_APP_WEBHOOK_SECRET`.
+   - Create GitHub App client for installation tokens + HMAC verification.
+   - Add `/webhooks/github/app` controller to verify signature and enqueue normalized events (thin handler).
+   - Emit receipt logs/metrics (delivery id, event type, installation id, repo).
+2) Event dispatch (worker entry)
+   - Define a normalized envelope type (repo, owner, installation id, PR number, head/base, labels, files summary, delivery id, dedupe key).
+   - Add dispatcher that fetches `.shipsec/workflows.yml` via installation token (fallback to default), selects matching workflows, builds idempotent key + per-repo concurrency guard, and starts workflows via the runner.
+   - Map workflow names to Temporal entry points (e.g., `shipsec-run-pr-trufflehog`).
+3) GitHub Trigger node (no-code surface)
+   - Add a node type `github.pr.trigger` in the builder palette (visible) even though the transport is webhook-driven.
+   - Inputs: none user-supplied; it receives `event` schema (repo, owner, prNumber, headSha, headBranch, baseBranch, author, labels, files?).
+   - Outputs: passes event metadata downstream; marks the run as “triggered by GitHub”.
+4) Repo fetch + execution
+   - Provide a built-in “Fetch repository” action that uses the installation token to download the head commit tarball/zip and yields `workspacePath`.
+   - Components (e.g., trufflehog) accept `workspacePath` and optional globs/limits; runner mounts the workspace into the container.
+5) Feedback to GitHub
+   - Service to create/update `check_run` per workflow (queued → in_progress → completed with conclusion + Studio URL).
+   - Optional PR comment summarizing findings; keep non-blocking until policy toggles exist.
+6) Observability + retries
+   - Dedupe redeliveries via delivery id + head SHA; log event→run mapping; metrics for queue/start/finish/error.
+   - Surface last webhook receipt and install status in Connections UI.
+
+### Minimal GitHub Trigger node schema (proposed)
+- **type**: `github.pr.trigger`
+- **inputs**: none (system-provided)
+- **outputs** (object):
+  - `repository`: { `owner`: string; `name`: string }
+  - `prNumber`: number
+  - `head`: { `sha`: string; `ref`: string }
+  - `base`: { `sha`: string; `ref`: string }
+  - `author`: string
+  - `labels`: string[]
+  - `files`: optional array of { `path`: string; `status`: string }
+  - `deliveryId`: string
+
+### Example no-code flow (trufflehog on PR)
+`[GitHub PR Trigger] → [Fetch repository] → [Trufflehog Scan] → [Summarize] → [Publish GitHub Check/Comment]`
+
+### Quick demo path (no Redis/queues)
+- Purpose: show end-to-end webhook → Temporal run in minutes for a demo. Not production-grade.
+- What it does: webhook → signature verify → normalize envelope → in-memory dedupe → starts Temporal `minimalWorkflow` with the envelope as args (workflowId `github-demo-<dedupe>`). No config lookup, no repo fetch, no GitHub feedback.
+- Requirements: Temporal reachable (env `TEMPORAL_ADDRESS`, default `localhost:7233`), GitHub App creds/env set, backend running.
+- Run: start backend normally; install GitHub App webhook to `/api/v1/webhooks/github/app`; open a PR or resync to fire a webhook.
+- Follow-ups after demo: replace in-memory dedupe with Redis/DB, add repo config resolution + actual workflow start, add check_run feedback, and remove the demo starter once proper dispatch is in place.
+
+### New component for repo checkout (to feed scanners like trufflehog)
+- `github.pr.checkout` (worker): inputs `repoFullName`, `ref` (branch or SHA), optional `token`, `depth` (default 1), `clean` (default false). It shallow-clones the PR head into an isolated temp dir and outputs `{ workspacePath, repoFullName, ref, commitSha }` for downstream components to consume. In pipelines, wire the GitHub trigger metadata into this node, then pass `workspacePath` to scanners. Clean=true deletes checkout after run (leave false when a downstream component needs the path).  

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -4,8 +4,11 @@ VITE_API_URL=http://localhost:3211
 # Application Configuration
 VITE_APP_NAME=Security Workflow Builder
 VITE_APP_VERSION=1.0.0
+
+# GitHub App install URL (for Connections GitHub App CTA)
+VITE_GITHUB_APP_INSTALL_URL=
+
 # PostHog Analytics
 # Copy to .env or .env.local and set values
 VITE_PUBLIC_POSTHOG_KEY=
 VITE_PUBLIC_POSTHOG_HOST=
-

--- a/frontend/src/components/workflow/nodes/definitions/githubTrigger.ts
+++ b/frontend/src/components/workflow/nodes/definitions/githubTrigger.ts
@@ -1,0 +1,67 @@
+import { ComponentMetadata } from '@/schemas/component'
+
+export const githubTriggerComponent: ComponentMetadata = {
+  id: 'github.pr.trigger',
+  slug: 'github-pr-trigger',
+  name: 'GitHub PR Trigger',
+  version: '1.0.0',
+  type: 'trigger',
+  category: 'input',
+  categoryConfig: {
+    label: 'Triggers',
+    color: '#2563eb',
+    description: 'Entrypoints that start workflows',
+    emoji: '🛰️',
+  },
+  description: 'Starts a run from a GitHub pull_request event and provides PR metadata',
+  icon: 'github',
+  runner: { kind: 'inline' },
+  inputs: [],
+  outputs: [
+    {
+      id: 'repository',
+      label: 'Repository',
+      dataType: { kind: 'map', value: { kind: 'primitive', name: 'text' } },
+      description: 'owner/name',
+    },
+    {
+      id: 'prNumber',
+      label: 'PR Number',
+      dataType: { kind: 'primitive', name: 'number' },
+    },
+    {
+      id: 'head',
+      label: 'Head',
+      dataType: { kind: 'map', value: { kind: 'primitive', name: 'text' } },
+      description: 'sha and ref of the head',
+    },
+    {
+      id: 'base',
+      label: 'Base',
+      dataType: { kind: 'map', value: { kind: 'primitive', name: 'text' } },
+      description: 'sha and ref of the base',
+    },
+    {
+      id: 'author',
+      label: 'Author',
+      dataType: { kind: 'primitive', name: 'text' },
+    },
+    {
+      id: 'labels',
+      label: 'Labels',
+      dataType: { kind: 'list', element: { kind: 'primitive', name: 'text' } },
+    },
+    {
+      id: 'files',
+      label: 'Files (optional)',
+      dataType: { kind: 'list', element: { kind: 'primitive', name: 'text' } },
+    },
+    {
+      id: 'deliveryId',
+      label: 'Delivery ID',
+      dataType: { kind: 'primitive', name: 'text' },
+    },
+  ],
+  parameters: [],
+  examples: [],
+}

--- a/frontend/src/pages/IntegrationsManager.tsx
+++ b/frontend/src/pages/IntegrationsManager.tsx
@@ -33,6 +33,10 @@ import { api } from '@/services/api'
 type IntegrationProvider = components['schemas']['IntegrationProviderResponse']
 type IntegrationConnection = components['schemas']['IntegrationConnectionResponse']
 
+const GITHUB_APP_INSTALL_URL = import.meta.env.VITE_GITHUB_APP_INSTALL_URL || ''
+const GITHUB_WEBHOOK_PATH = '/api/v1/webhooks/github/app'
+const GITHUB_WEBHOOK_URL = `${window.location.origin}${GITHUB_WEBHOOK_PATH}`
+
 function formatTimestamp(iso: string | null | undefined): string {
   if (!iso) {
     return '—'
@@ -197,6 +201,22 @@ const buildRequestedScopes = (provider: IntegrationProvider): string[] => {
       })
     } finally {
       setRefreshingConnectionId(null)
+    }
+  }
+
+  const handleCopyWebhook = async () => {
+    try {
+      await navigator.clipboard.writeText(GITHUB_WEBHOOK_URL)
+      toast({
+        title: 'Webhook URL copied',
+        description: GITHUB_WEBHOOK_URL,
+      })
+    } catch (err) {
+      toast({
+        title: 'Copy failed',
+        description: err instanceof Error ? err.message : 'Could not copy webhook URL',
+        variant: 'destructive',
+      })
     }
   }
 
@@ -383,6 +403,46 @@ const buildRequestedScopes = (provider: IntegrationProvider): string[] => {
                 </tbody>
               </table>
             </div>
+          )}
+        </section>
+
+        <section className="bg-card border rounded-lg p-5 space-y-3">
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <h2 className="text-lg font-semibold">GitHub App (PR triggers)</h2>
+              <p className="text-sm text-muted-foreground">
+                Install the ShipSec GitHub App for webhooks and repo-scoped tokens. OAuth below remains for user-scoped calls.
+              </p>
+              <div className="flex flex-wrap gap-2 text-xs text-muted-foreground mt-2">
+                <span className="font-medium">Webhook URL:</span>
+                <code className="px-2 py-1 bg-muted rounded text-[11px]">{GITHUB_WEBHOOK_URL}</code>
+                <Button variant="ghost" size="xs" className="h-6 px-2 gap-2" onClick={handleCopyWebhook}>
+                  <Copy className="h-3 w-3" />
+                  Copy
+                </Button>
+              </div>
+            </div>
+            <Button
+              asChild
+              disabled={!GITHUB_APP_INSTALL_URL}
+              variant={GITHUB_APP_INSTALL_URL ? 'default' : 'secondary'}
+              className="gap-2"
+            >
+              <a
+                href={GITHUB_APP_INSTALL_URL || '#'}
+                target="_blank"
+                rel="noopener noreferrer"
+                aria-disabled={!GITHUB_APP_INSTALL_URL}
+              >
+                <ExternalLink className="h-4 w-4" />
+                {GITHUB_APP_INSTALL_URL ? 'Install GitHub App' : 'Set VITE_GITHUB_APP_INSTALL_URL'}
+              </a>
+            </Button>
+          </div>
+          {!GITHUB_APP_INSTALL_URL && (
+            <p className="text-xs text-muted-foreground">
+              Set <code>VITE_GITHUB_APP_INSTALL_URL</code> to your app’s installation link to enable the button.
+            </p>
           )}
         </section>
 

--- a/frontend/src/store/componentStore.ts
+++ b/frontend/src/store/componentStore.ts
@@ -1,6 +1,7 @@
 import { create } from 'zustand'
 import { ComponentMetadata } from '@/schemas/component'
 import { api } from '@/services/api'
+import { githubTriggerComponent } from '@/components/workflow/nodes/definitions/githubTrigger'
 
 interface ComponentStoreState {
   components: Record<string, ComponentMetadata>
@@ -26,7 +27,9 @@ function buildIndexes(components: any[]) {
   const byId: Record<string, ComponentMetadata> = {}
   const slugIndex: Record<string, string> = {}
 
-  components.forEach((component) => {
+  const allComponents = [...components, githubTriggerComponent]
+
+  allComponents.forEach((component) => {
     // Filter out components missing required fields
     if (!component?.id || !component?.slug || !component?.name) {
       return

--- a/worker/src/components/github/pr-checkout.ts
+++ b/worker/src/components/github/pr-checkout.ts
@@ -1,0 +1,91 @@
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+import { z } from 'zod';
+import { componentRegistry, ComponentDefinition } from '@shipsec/component-sdk';
+
+const execFileAsync = promisify(execFile);
+
+const inputSchema = z.object({
+  repoFullName: z.string().min(1).describe('owner/repo'),
+  ref: z.string().min(1).describe('Branch name or commit SHA'),
+  token: z.string().min(1).optional().describe('GitHub token (installation/user) for private repos'),
+  depth: z.number().int().positive().max(1000).default(1).describe('Shallow clone depth'),
+  clean: z.boolean().default(false).describe('Remove the checkout after completion'),
+});
+
+type Input = z.infer<typeof inputSchema>;
+
+const outputSchema = z.object({
+  workspacePath: z.string(),
+  repoFullName: z.string(),
+  ref: z.string(),
+  commitSha: z.string(),
+});
+
+type Output = z.infer<typeof outputSchema>;
+
+const shaPattern = /^[0-9a-f]{7,40}$/i;
+
+async function runGit(args: string[], cwd?: string) {
+  const { stdout, stderr } = await execFileAsync('git', args, {
+    cwd,
+    env: { ...process.env, GIT_TERMINAL_PROMPT: '0' },
+    timeout: 5 * 60 * 1000,
+  });
+  return { stdout: stdout?.trim() ?? '', stderr: stderr?.trim() ?? '' };
+}
+
+async function checkoutRepo(input: Input): Promise<Output> {
+  const baseDir = await mkdtemp(join(tmpdir(), 'shipsec-github-'));
+  const repoPath = join(baseDir, 'repo');
+
+  const authPrefix = input.token ? `https://x-access-token:${input.token}@` : 'https://';
+  const repoUrl = `${authPrefix}github.com/${input.repoFullName}.git`;
+
+  // Clone shallow by ref (branch) when possible; fall back to fetch/checkout for SHAs
+  const cloneArgs = ['clone', '--no-tags', `--depth=${input.depth}`, repoUrl, repoPath];
+  if (!shaPattern.test(input.ref)) {
+    cloneArgs.splice(3, 0, '--branch', input.ref);
+  }
+
+  await runGit(cloneArgs);
+
+  if (shaPattern.test(input.ref)) {
+    await runGit(['fetch', 'origin', input.ref], repoPath);
+    await runGit(['checkout', input.ref], repoPath);
+  }
+
+  const { stdout } = await runGit(['rev-parse', 'HEAD'], repoPath);
+  const commitSha = stdout.trim();
+
+  // Clean up if requested (may not be desirable in pipelines that need the path after completion)
+  if (input.clean) {
+    await rm(baseDir, { recursive: true, force: true });
+  }
+
+  return {
+    workspacePath: input.clean ? '' : repoPath,
+    repoFullName: input.repoFullName,
+    ref: input.ref,
+    commitSha,
+  };
+}
+
+const component: ComponentDefinition<Input, Output> = {
+  id: 'github.pr.checkout',
+  name: 'GitHub PR Checkout',
+  description: 'Fetches a PR branch/commit into an isolated workspace for downstream scanners.',
+  icon: 'github',
+  inputSchema,
+  outputSchema,
+  requiresSecrets: false,
+  run: async (params) => {
+    return checkoutRepo(params);
+  },
+};
+
+componentRegistry.register(component);

--- a/worker/src/components/index.ts
+++ b/worker/src/components/index.ts
@@ -44,6 +44,7 @@ import './security/trufflehog';
 // GitHub components
 import './github/connection-provider';
 import './github/remove-org-membership';
+import './github/pr-checkout';
 
 // IT Automation components
 import './it-automation/google-workspace-license-unassign';


### PR DESCRIPTION
## Summary
- add GitHub App config, webhook controller, and demo dispatch to minimal workflow
- add GitHub PR checkout component and GitHub PR Trigger node to builder; update Connections with GitHub App CTA
- update env examples, compose, and docs for GitHub App setup and PR flow

## Testing
- not run