### PR TITLE
fix(docker-runner): skip tty flag when pty unavailable

### DIFF
--- a/packages/component-sdk/src/runner.ts
+++ b/packages/component-sdk/src/runner.ts
@@ -207,7 +207,8 @@ async function runDockerWithPty<I, O>(
   const spawnPty = await loadPtySpawn();
   if (!spawnPty) {
     context.logger.warn('[Docker][PTY] node-pty unavailable; falling back to standard IO');
-    return runDockerWithStandardIO(dockerArgs, params, context, timeoutSeconds);
+    const argsWithoutTty = dockerArgs.filter((arg) => arg !== '-t' && arg !== '--tty');
+    return runDockerWithStandardIO(argsWithoutTty, params, context, timeoutSeconds);
   }
 
   return new Promise<O>((resolve, reject) => {


### PR DESCRIPTION
## Summary
- avoid passing -t/--tty when node-pty is unavailable so docker fallback uses stdio without TTY errors
- keep PTY mode unchanged when node-pty is present; warn then fall back otherwise

## Issue
- addresses subfinder runs failing with "the input device is not a TTY" when node-pty native module is missing

## Testing
- not run (needs workflow rerun)