### PR TITLE
docs: add contributing and security policies

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,47 @@
+# Contributing to ShipSec Studio
+
+Thank you for improving ShipSec Studio. This guide keeps contributions consistent, reviewable, and compliant with our legal and security expectations.
+
+## Quick Start
+- Fork or branch from `main`.
+- Keep subjects in Conventional Commit style (e.g., `feat:`, `fix:`, `docs:`) and reference the issue/milestone where relevant.
+- Run the core gates before opening a PR: `bun run test`, `bun run lint`, and `bun run typecheck`. Call out any intentional gaps in the PR description.
+- For backend integrations, prefer targeted checks when needed: `bun --cwd backend run migration:smoke`.
+- If you touch workflows or contracts, validate against `docs/execution-contract.md` and update fixtures/docs under `docs/` or `.ai/` as needed.
+
+## Reference Docs
+- `AGENTS.md` — repo layout, commands, testing gates, and PR expectations.
+- `.ai/` specs — `claude-spec.md`, `implementation-plan.md`, `visual-execution-notes.md` for contracts, observability, and roadmap context.
+- `docs/execution-contract.md` — workflow/trace schemas to validate API and UI changes.
+- Component patterns — `.ai/component-sdk.md` and `docs/component-development.md` (isolated volume requirement); `worker/src/utils/COMPONENTS_TO_MIGRATE.md` for migration status.
+
+## Developer Certificate of Origin (DCO)
+We require a DCO sign-off on every commit. Use `git commit -s` so Git appends a `Signed-off-by: Name <email>` line. If you forgot to sign off, amend and force-push the branch:
+
+```bash
+git commit --amend -s
+git push --force-with-lease
+```
+
+The repository enforces a DCO status check on pull requests; unsignoffed commits will fail CI until corrected.
+
+## Pull Request Checklist
+- Tests, lint, and type checks pass (or documented exceptions).
+- New or changed behaviour is covered with tests near the code (`__tests__`, `*.spec.ts`/`*.test.ts`).
+- Docs/runbooks updated when contracts, workflows, or operational steps change.
+- Keep workflow/run identifiers in the `shipsec-run-*` shape and reuse shared Zod schemas from `@shipsec/shared` instead of ad-hoc types.
+- Screenshots or trace snippets included for UI/observability changes when helpful.
+
+## Code Review Expectations
+- Keep diffs focused and avoid unrelated formatting churn.
+- Explain risk areas and validation performed in the PR description.
+- If a check is flaky or blocked, note it explicitly so reviewers know what was attempted.
+
+## Security & Sensitive Changes
+- Avoid committing secrets; prefer `.env.example` updates for new settings.
+- For vulnerability reports, follow the process in `SECURITY.md` (private disclosure first).
+- Components that interact with Docker must follow the isolated volume pattern described in `.ai/component-sdk.md` and `docs/component-development.md`.
+
+## Getting Help
+- Open a GitHub discussion/issue with module context (frontend/backend/worker/packages).
+- Internal team: share blocking details (logs, run IDs, Loki queries) in the PR or chat to speed triage.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,23 @@
+# Security Policy
+
+We take security and user trust seriously. Please use the private channels below to report vulnerabilities so we can assess and remediate before public disclosure.
+
+## Reporting a Vulnerability
+- Preferred: Open a private advisory via GitHub’s “Report a vulnerability” link for this repository.
+- Alternative: Email `security@shipsec.ai` with a clear subject (e.g., `Vulnerability report: <area>`).
+
+Please include:
+- Affected area (frontend, backend, worker, shared package) and commit/branch if known.
+- Reproduction steps or proof-of-concept.
+- Impact assessment (confidentiality/integrity/availability) and any prerequisites.
+- Suggested fixes or mitigations if you have them.
+
+We aim to acknowledge new reports within 3 business days and provide an initial remediation plan or timeline within 10 business days.
+
+## Scope & Expectations
+- Do not test against production data you do not own. Avoid actions that degrade availability.
+- Respect privacy and data integrity; use test tenants/accounts where possible.
+- No bounties are currently offered; coordinated disclosure credit is provided in release notes when applicable.
+
+## Handling Secrets
+- Never include real secrets or tokens in issues, PRs, or logs. Use `.env.example` for new configuration keys and follow existing patterns for secret management.


### PR DESCRIPTION
## Summary
- add CONTRIBUTING.md with DCO, workflow gates, and reference docs
- add SECURITY.md with private vuln reporting process and scope

Fixes #121