### PR TITLE
fix: Remove hardcoded subfinder reference from workflow-runner.ts

### DIFF
--- a/worker/scripts/workflow-runner.ts
+++ b/worker/scripts/workflow-runner.ts
@@ -91,7 +91,6 @@ async function listRuns(
   const runs: ListEntry[] = [];
   const maxMatches = Math.max(limit * 3, limit);
 
-  const subfinderRef = definition.actions.find((action) => action.componentId === 'shipsec.subfinder.run')?.ref;
   const query = 'WorkflowType = "shipsecWorkflowRun"';
 
   for await (const info of client.workflow.list({ query, pageSize: 50 })) {
@@ -131,13 +130,6 @@ async function listRuns(
     try {
       const result = await handle.result();
       entry.result = result;
-      const outputs = (result as any)?.outputs ?? {};
-      if (subfinderRef && outputs[subfinderRef]) {
-        entry.result = {
-          ...result,
-          subfinder: outputs[subfinderRef],
-        };
-      }
     } catch (error) {
       entry.error = error instanceof Error ? error.message : String(error);
     }


### PR DESCRIPTION
## Summary

Removes undocumented hardcoded reference to `shipsec.subfinder.run` component from the workflow-runner debug script.

## Changes

- Removed hardcoded `subfinderRef` lookup (line 94)
- Removed special subfinder output handling (lines 135-139)
- Script now treats all components equally

## Rationale

As documented in #117:
- ❌ No documentation found for this behavior
- ❌ Creates inconsistent behavior (only one component gets special treatment)
- ❌ Not scalable (would need more hardcoded refs for other components)
- ✅ Script works fine without it

## Testing

- ✅ No linter errors
- ✅ Code compiles successfully
- Script functionality preserved (still lists/runs workflows correctly)

Closes #117