### PR TITLE
fix(env): align TEMPORAL_TASK_QUEUE across all .env files

### DIFF
--- a/backend/.env.docker
+++ b/backend/.env.docker
@@ -8,8 +8,8 @@ PORT="3211"
 
 # Temporal connection details (Docker network)
 TEMPORAL_ADDRESS="temporal:7233"
-TEMPORAL_NAMESPACE="shipsec-dev"
-TEMPORAL_TASK_QUEUE="shipsec-default"
+TEMPORAL_NAMESPACE="shipsec-prod"
+TEMPORAL_TASK_QUEUE="shipsec-prod"
 # Automatically create and run a demo workflow on startup
 TEMPORAL_BOOTSTRAP_DEMO="false"
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -9,7 +9,7 @@ PORT="3211"
 # Temporal connection details
 TEMPORAL_ADDRESS="localhost:7233"
 TEMPORAL_NAMESPACE="shipsec-dev"
-TEMPORAL_TASK_QUEUE="shipsec-default"
+TEMPORAL_TASK_QUEUE="shipsec-dev"
 # Automatically create and run a demo workflow on startup
 TEMPORAL_BOOTSTRAP_DEMO="false"
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -6,7 +6,7 @@
   - `DATABASE_URL` – Postgres connection string (matches the `postgres` service in `docker-compose.yml` by default).
   - `TEMPORAL_ADDRESS` – Temporal server host:port (default `localhost:7233` when running docker compose).
   - `TEMPORAL_NAMESPACE` – Namespace to operate within (default `shipsec-dev`).
-- `TEMPORAL_TASK_QUEUE` – Task queue used for ShipSec workflows (default `shipsec-default`).
+  - `TEMPORAL_TASK_QUEUE` – Task queue used for ShipSec workflows (default `shipsec-dev` for local, `shipsec-prod` for Docker).
 - `TEMPORAL_BOOTSTRAP_DEMO` – Set to `true` to auto-create and run the demo workflow at startup (appears in Temporal UI).
 - `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` – Credentials for the MinIO console/API (`minioadmin` by default).
 - `SECRET_STORE_MASTER_KEY` – 32-byte master key (base64, hex, or UTF-8) used to encrypt secrets. Defaults to a development key when unset.

--- a/worker/.env.example
+++ b/worker/.env.example
@@ -11,6 +11,7 @@ MINIO_BUCKET_NAME=shipsec-files
 # Temporal Configuration
 TEMPORAL_ADDRESS=localhost:7233
 TEMPORAL_NAMESPACE=shipsec-dev
+TEMPORAL_TASK_QUEUE=shipsec-dev
 
 # Loki Configuration
 LOKI_URL=http://localhost:3100


### PR DESCRIPTION
## Summary

- Align `.env.example` and `.env.docker` files with the PM2 task queue configuration from commit 7858a27
- Prevent workflow execution failures caused by queue mismatch between backend and worker

## Problem

After commit `7858a27` introduced environment-specific task queues in PM2:
- Development: `shipsec-dev`
- Production: `shipsec-prod`

The `.env.example` files still used the old `shipsec-default` value. This caused issues when:

1. **Running without PM2** (`bun run dev` directly) - services used `.env` values
2. **New developer setup** - copying `.env.example` → `.env` gave wrong queue
3. **Docker deployments** - `.env.docker` had inconsistent values

### Symptom
Workflows appeared as "Running" but never progressed because:
```
Backend → starts workflow on queue "shipsec-default"
Worker  → listens on queue "shipsec-dev" (from PM2)
Result  → No worker picks up the workflow, stuck forever
```

## Changes

| File | Before | After |
|------|--------|-------|
| `backend/.env.example` | `shipsec-default` | `shipsec-dev` |
| `worker/.env.example` | (missing) | `shipsec-dev` |
| `backend/.env.docker` | `shipsec-default` | `shipsec-prod` |
| `backend/README.md` | docs said `shipsec-default` | Updated to reflect new defaults |

## Environment Loading Summary

| Startup Method | Task Queue |
|----------------|------------|
| `just dev` / `bun run dev:stack` | `shipsec-dev` (PM2) |
| `just up` | `shipsec-prod` (Docker) |
| Direct `bun run dev` | `.env` file value (now `shipsec-dev`) |

## Test plan

- [x] Run `just dev` and verify worker logs show `shipsec-dev` queue
- [x] Run `just up` and verify services use `shipsec-prod` queue
- [x] Copy `.env.example` → `.env` and run directly - should use `shipsec-dev`
- [x] Execute a workflow and confirm it completes (not stuck)

<img width="527" height="96" alt="image" src="https://github.com/user-attachments/assets/d02864d0-adf4-4028-9e9e-94a5532a1e9b" />
<img width="527" height="97" alt="image" src="https://github.com/user-attachments/assets/dd19cedd-ddca-40cf-9168-90bd5a2b10eb" />
