### PR TITLE
feat(execution): add copy link button and auto-navigate to new runs

### DIFF
--- a/frontend/src/components/ui/toast-provider.tsx
+++ b/frontend/src/components/ui/toast-provider.tsx
@@ -107,7 +107,7 @@ export function ToastProvider({ children }: { children: React.ReactNode }) {
             className={cn(
               // Dark, high-contrast base + subtle ring by variant
               'pointer-events-auto flex w-full max-w-sm items-start justify-between gap-4 rounded-md px-4 py-3 sm:max-w-md rounded-xl',
-              'border border-white/80 bg-white/95 text-neutral-900 shadow-lg shadow-black/10 ring-1 ring-black/5 backdrop-blur-sm',
+              'border border-neutral-200 bg-white/95 text-neutral-900 shadow-lg shadow-black/10 ring-1 ring-black/5 backdrop-blur-sm',
               variantStyles[variant] ?? '',
             )}
           >

--- a/frontend/src/pages/WorkflowBuilder.tsx
+++ b/frontend/src/pages/WorkflowBuilder.tsx
@@ -686,6 +686,8 @@ function WorkflowBuilderContent() {
           // Use setTimeout to allow state updates to settle first
           setTimeout(() => setMode('execution'), 0)
         }
+        // Navigate to the new run URL so user can see and share it
+        navigate(`/workflows/${workflowId}/runs/${runId}`, { replace: true })
         // Timeline will be populated by live updates from execution store subscription
         toast({
           variant: 'success',


### PR DESCRIPTION
## Summary
- Add copy link icon button to run card in ExecutionInspector for easy sharing
- Auto-navigate to new run URL when workflow execution starts
- Ensures latest run is always selected and URL is immediately shareable

## Changes
1. **ExecutionInspector.tsx**: Added `Link2` icon button next to version/status badges that copies the run URL to clipboard with toast feedback
2. **WorkflowBuilder.tsx**: Added `navigate()` call after starting execution to update URL to `/workflows/{id}/runs/{runId}`

Fixes : [ENG-66](https://linear.app/shipsec-ai/issue/ENG-66)

## Test plan
- [x] Execute a workflow and verify URL updates to include the run ID
- [x] Click the copy link icon on the run card and verify URL is copied to clipboard
- [x] Verify toast notification appears after copying
- [x] With multiple live runs, execute a new workflow and verify it switches to the new run