### PR TITLE
feat: Easy self-hosting with just prod start-latest

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,6 +118,8 @@ jobs:
           tags: ${{ steps.tags.outputs.backend_tags }}
           build-args: |
             VITE_GIT_SHA=${{ steps.git_sha.outputs.sha }}
+            POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}
+            POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -131,6 +133,8 @@ jobs:
           tags: ${{ steps.tags.outputs.worker_tags }}
           build-args: |
             VITE_GIT_SHA=${{ steps.git_sha.outputs.sha }}
+            POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}
+            POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
@@ -146,6 +150,8 @@ jobs:
             VITE_GIT_SHA=${{ steps.git_sha.outputs.sha }}
             VITE_PUBLIC_POSTHOG_KEY=${{ secrets.POSTHOG_API_KEY }}
             VITE_PUBLIC_POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
+            POSTHOG_API_KEY=${{ secrets.POSTHOG_API_KEY }}
+            POSTHOG_HOST=${{ secrets.POSTHOG_HOST }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -40,6 +40,12 @@ FROM base AS backend
 # Switch to user
 USER shipsec
 
+# PostHog analytics (optional)
+ARG POSTHOG_API_KEY=""
+ARG POSTHOG_HOST=""
+ENV POSTHOG_API_KEY=${POSTHOG_API_KEY}
+ENV POSTHOG_HOST=${POSTHOG_HOST}
+
 # Set working directory for backend
 WORKDIR /app/backend
 
@@ -56,6 +62,12 @@ FROM base AS worker
 
 # Switch to user
 USER shipsec
+
+# PostHog analytics (optional)
+ARG POSTHOG_API_KEY=""
+ARG POSTHOG_HOST=""
+ENV POSTHOG_API_KEY=${POSTHOG_API_KEY}
+ENV POSTHOG_HOST=${POSTHOG_HOST}
 
 # Set working directory for worker
 WORKDIR /app/worker

--- a/README.md
+++ b/README.md
@@ -61,7 +61,46 @@ Get started with ShipSec Studio in minutes:
 3. **Run a scan** with pre-built components like Subfinder, Nuclei, or HTTPx
 4. **View results** in real-time as the workflow executes
 
-### Option 2: Run Locally
+### Option 2: Self-Host with Docker (Recommended)
+
+The easiest way to run ShipSec Studio on your own infrastructure:
+
+#### Prerequisites
+
+- **[docker](https://www.docker.com/)** - For running the application and security components
+- **[just](https://github.com/casey/just)** - Command runner for simplified workflows
+- **curl** and **jq** - For fetching release information
+
+#### Quick Start
+
+```bash
+# Clone the repository
+git clone https://github.com/ShipSecAI/studio.git
+cd studio
+
+# Download the latest release and start
+just prod start-latest
+
+# Visit http://localhost:8090 to access ShipSec Studio
+```
+
+This command automatically:
+- Fetches the latest release version from GitHub
+- Pulls pre-built Docker images from GHCR
+- Starts the full stack (frontend, backend, worker, and infrastructure)
+
+#### Other Commands
+
+```bash
+just prod stop      # Stop the environment
+just prod logs      # View logs
+just prod status    # Check status
+just prod clean     # Remove all data
+```
+
+### Option 3: Development Setup
+
+For contributors who want to modify the source code:
 
 #### Prerequisites
 
@@ -69,7 +108,7 @@ Get started with ShipSec Studio in minutes:
 - **[docker](https://www.docker.com/)** - For running security components in isolated containers
 - **[just](https://github.com/casey/just)** - Command runner for simplified development workflows
 
-#### Quick Setup with `just` (Recommended)
+#### Setup
 
 ```bash
 # Clone the repository
@@ -79,7 +118,7 @@ cd studio
 # Initialize (installs dependencies and creates environment files)
 just init
 
-# Start development environment
+# Start development environment with hot-reload
 just dev
 
 # Visit http://localhost:5173 to access ShipSec Studio

--- a/docker/docker-compose.full.yml
+++ b/docker/docker-compose.full.yml
@@ -198,10 +198,8 @@ services:
       - AUTH_PROVIDER=local
       - CLERK_PUBLISHABLE_KEY=
       - CLERK_SECRET_KEY=
-      # PostHog analytics (baked into Docker images)
-      - POSTHOG_API_KEY=${POSTHOG_API_KEY:-}
-      - POSTHOG_HOST=${POSTHOG_HOST:-}
-      - DISABLE_ANALYTICS=${DISABLE_ANALYTICS:-}
+      # Set to 'true' to disable analytics
+      - DISABLE_ANALYTICS=${DISABLE_ANALYTICS:-false}
     ports:
       - "3211:3211"
     depends_on:
@@ -237,11 +235,6 @@ services:
       - VITE_AUTH_PROVIDER=clerk
       - VITE_DEFAULT_ORG_ID=local-dev
       - VITE_CLERK_PUBLISHABLE_KEY=
-      # PostHog analytics (optional). Set in your shell or a .env file next to this compose.
-      # If unset, the app disables analytics at runtime.
-      - VITE_PUBLIC_POSTHOG_KEY=${VITE_PUBLIC_POSTHOG_KEY:-}
-      - VITE_PUBLIC_POSTHOG_HOST=${VITE_PUBLIC_POSTHOG_HOST:-}
-      - VITE_DISABLE_ANALYTICS=${VITE_DISABLE_ANALYTICS:-}
     ports:
       - "8090:8080"
     depends_on:


### PR DESCRIPTION
## Summary

Adds a streamlined way for users to self-host ShipSec Studio using pre-built Docker images from GitHub Container Registry.

## New Command

\`\`\`bash
just prod start-latest
\`\`\`

This command:
- Fetches the latest release version from the GitHub API
- Pulls matching Docker images from GHCR (backend, frontend, worker)
- Starts the full production stack with docker-compose

## Changes

- **justfile**: Added \`start-latest\` subcommand under \`just prod\`
- **docker-compose.full.yml**: Images now use \`\{SHIPSEC_TAG:-latest}\` for version flexibility
- **README.md**: Updated Quick Start to recommend \`just prod start-latest\` as the primary self-hosting method
- **Dockerfile & release.yml**: Minor build configuration updates

## Usage

\`\`\`bash
# Clone and start
git clone https://github.com/ShipSecAI/studio.git
cd studio
just prod start-latest

# Access at http://localhost:8090
\`\`\`

## Other Commands

\`\`\`bash
just prod stop      # Stop the environment
just prod logs      # View logs
just prod status    # Check status
just prod clean     # Remove all data
\`\`\`