### PR TITLE
fix(arm-build): added the arm64 builds to CI pipeline

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,6 +29,9 @@ jobs:
         with:
           fetch-depth: 0  # Full history for changelog generation
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -115,6 +118,7 @@ jobs:
           file: ./Dockerfile
           target: backend
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.tags.outputs.backend_tags }}
           build-args: |
             VITE_GIT_SHA=${{ steps.git_sha.outputs.sha }}
@@ -130,6 +134,7 @@ jobs:
           file: ./Dockerfile
           target: worker
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.tags.outputs.worker_tags }}
           build-args: |
             VITE_GIT_SHA=${{ steps.git_sha.outputs.sha }}
@@ -145,6 +150,7 @@ jobs:
           file: ./Dockerfile
           target: frontend
           push: true
+          platforms: linux/amd64,linux/arm64
           tags: ${{ steps.tags.outputs.frontend_tags }}
           build-args: |
             VITE_GIT_SHA=${{ steps.git_sha.outputs.sha }}


### PR DESCRIPTION
# Summary
- Added QEMU setup (line 32-33) - Required for cross-platform emulation when building ARM64 images on AMD64 runners
- Added platforms to all three image builds

# Testing
- [ ] `bun run test`
- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [ ] Additional notes:

# Documentation
- [ ] Updated the relevant doc(s) (see `docs/guide.md`) or checked that no updates are needed.
- [ ] Recorded contract/architecture changes in both public docs and `.ai` logs when applicable.
