### PR TITLE
fix(frontend): use ES module import for tailwind colors

### DIFF
--- a/frontend/tailwind.config.js
+++ b/frontend/tailwind.config.js
@@ -1,4 +1,5 @@
 import tailwindTypography from '@tailwindcss/typography'
+import tailwindColors from 'tailwindcss/colors'
 
 /** @type {import('tailwindcss').Config} */
 export default {
@@ -30,7 +31,7 @@ export default {
   	},
   	colors: (() => {
 		// Exclude deprecated color names to silence Tailwind v3 warnings
-		const { lightBlue, warmGray, trueGray, coolGray, blueGray, ...colors } = require('tailwindcss/colors')
+		const { lightBlue, warmGray, trueGray, coolGray, blueGray, ...colors } = tailwindColors
 		return {
 			...colors,
 			// Custom semantic colors (override defaults)


### PR DESCRIPTION
## Summary
- Replace CommonJS `require('tailwindcss/colors')` with ES module `import tailwindColors from 'tailwindcss/colors'`
- Maintains consistency with other imports in the file

## Test plan
- [x] Verify frontend builds without warnings
- [x] Check tailwind colors render correctly

Fixes: ENG-93