### PR TITLE
fix(frontend): update webhook URLs to include global api prefix

### DIFF
--- a/frontend/src/components/auth/AdminLoginForm.tsx
+++ b/frontend/src/components/auth/AdminLoginForm.tsx
@@ -5,7 +5,7 @@ import { Label } from '@/components/ui/label';
 import { useAuthStore } from '@/store/authStore';
 import { useNavigate } from 'react-router-dom';
 import { LogIn } from 'lucide-react';
-import { API_BASE_URL } from '@/services/api';
+import { API_V1_URL } from '@/services/api';
 
 export function AdminLoginForm() {
   const [username, setUsername] = useState('');
@@ -34,7 +34,7 @@ export function AdminLoginForm() {
       // Test the credentials by making a simple API call
       // If it fails, the credentials are invalid
       const credentials = btoa(`${trimmedUsername}:${trimmedPassword}`);
-      const response = await fetch(`${API_BASE_URL}/api/v1/workflows`, {
+      const response = await fetch(`${API_V1_URL}/workflows`, {
         headers: {
           Authorization: `Basic ${credentials}`,
           'Content-Type': 'application/json',

--- a/frontend/src/components/timeline/AgentTracePanel.tsx
+++ b/frontend/src/components/timeline/AgentTracePanel.tsx
@@ -13,7 +13,7 @@ import { Badge } from '@/components/ui/badge';
 import { useExecutionTimelineStore } from '@/store/executionTimelineStore';
 import { useWorkflowUiStore } from '@/store/workflowUiStore';
 import { useRunStore } from '@/store/runStore';
-import { api, buildApiUrl, getApiAuthHeaders } from '@/services/api';
+import { api, API_V1_URL, getApiAuthHeaders } from '@/services/api';
 import { cn } from '@/lib/utils';
 import type {
   AgentNodeOutput,
@@ -755,7 +755,7 @@ function useAgentTranscript(agentRunId: string | null): AgentTranscriptState {
       setState((prev) => ({ ...prev, loading: true, error: null }));
       try {
         const headers = await getApiAuthHeaders();
-        const response = await fetch(buildApiUrl(`/api/v1/agents/${agentRunId}/parts`), {
+        const response = await fetch(`${API_V1_URL}/agents/${agentRunId}/parts`, {
           headers,
         });
         if (!response.ok) {
@@ -835,7 +835,7 @@ function useAgentChatTransport(agentRunId: string | null) {
       prepareSendMessagesRequest: async ({ body, headers }) => {
         const authHeaders = await getApiAuthHeaders();
         return {
-          api: buildApiUrl(`/api/v1/agents/${agentRunId}/chat`),
+          api: `${API_V1_URL}/agents/${agentRunId}/chat`,
           body: body ?? {},
           headers: {
             ...headersInitToRecord(headers),
@@ -846,7 +846,7 @@ function useAgentChatTransport(agentRunId: string | null) {
       prepareReconnectToStreamRequest: async ({ headers }) => {
         const authHeaders = await getApiAuthHeaders();
         return {
-          api: buildApiUrl(`/api/v1/agents/${agentRunId}/chat`),
+          api: `${API_V1_URL}/agents/${agentRunId}/chat`,
           headers: {
             ...headersInitToRecord(headers),
             ...authHeaders,

--- a/frontend/src/components/workflow/ConfigPanel.tsx
+++ b/frontend/src/components/workflow/ConfigPanel.tsx
@@ -40,7 +40,7 @@ import {
   isListOfTextPort,
   resolvePortType,
 } from '@/utils/portUtils';
-import { API_BASE_URL, api } from '@/services/api';
+import { API_V1_URL, api } from '@/services/api';
 import { useWorkflowStore } from '@/store/workflowStore';
 import { useApiKeyStore } from '@/store/apiKeyStore';
 import type { WorkflowSchedule } from '@shipsec/shared';
@@ -627,8 +627,8 @@ export function ConfigPanel({
     }, {}),
   };
   const workflowInvokeUrl = workflowId
-    ? `${API_BASE_URL}/workflows/${workflowId}/run`
-    : `${API_BASE_URL}/workflows/{workflowId}/run`;
+    ? `${API_V1_URL}/workflows/${workflowId}/run`
+    : `${API_V1_URL}/workflows/{workflowId}/run`;
 
   return (
     <div

--- a/frontend/src/components/workflow/WorkflowNode.tsx
+++ b/frontend/src/components/workflow/WorkflowNode.tsx
@@ -45,7 +45,7 @@ import {
 import { inputSupportsManualValue, runtimeInputTypeToConnectionType } from '@/utils/portUtils';
 import { WebhookDetails } from './WebhookDetails';
 import { useApiKeyStore } from '@/store/apiKeyStore';
-import { API_BASE_URL } from '@/services/api';
+import { API_V1_URL } from '@/services/api';
 import { useNavigate, useParams } from 'react-router-dom';
 import { useEntryPointActions } from './entry-point-context';
 import { ShieldAlert, KeyRound } from 'lucide-react';
@@ -538,8 +538,8 @@ export const WorkflowNode = ({ data, selected, id }: NodeProps<NodeData>) => {
   const workflowIdFromRoute = params?.id && params.id !== 'new' ? params.id : undefined;
   const workflowId = workflowIdFromStore || workflowIdFromNode || workflowIdFromRoute;
   const workflowInvokeUrl = workflowId
-    ? `${API_BASE_URL}/api/v1/workflows/${workflowId}/run`
-    : `${API_BASE_URL}/api/v1/workflows/{workflowId}/run`;
+    ? `${API_V1_URL}/workflows/${workflowId}/run`
+    : `${API_V1_URL}/workflows/{workflowId}/run`;
 
   // Get schedule and webhook sidebar callbacks from Canvas context
   const { onOpenScheduleSidebar, onOpenWebhooksSidebar } = useEntryPointActions();

--- a/frontend/src/components/workflow/WorkflowWebhooksPanel.tsx
+++ b/frontend/src/components/workflow/WorkflowWebhooksPanel.tsx
@@ -5,13 +5,12 @@ import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { api } from '@/services/api';
 import type { WebhookConfiguration } from '@shipsec/shared';
-import { env } from '@/config/env';
 import { WebhookDetails } from './WebhookDetails';
 import { useApiKeyStore } from '@/store/apiKeyStore';
 import type { Node as ReactFlowNode } from 'reactflow';
 import type { FrontendNodeData } from '@/schemas/node';
 
-const WEBHOOK_BASE_URL = env.VITE_API_URL || 'https://api.shipsec.ai';
+import { API_V1_URL } from '@/services/api';
 
 // State passed when navigating to webhook editor from workflow
 export interface WebhookNavigationState {
@@ -220,7 +219,7 @@ export function WorkflowWebhooksSidebar({
         {!isLoading &&
           !error &&
           webhooks.map((webhook) => {
-            const webhookUrl = `${WEBHOOK_BASE_URL}/api/v1/webhooks/inbound/${webhook.webhookPath}`;
+            const webhookUrl = `${API_V1_URL}/webhooks/inbound/${webhook.webhookPath}`;
 
             // Generate a sample payload that combines expectedInputs with generic fields
             // to show it can accept "whatever payload"

--- a/frontend/src/features/workflow-builder/components/WorkflowDesignerPane.tsx
+++ b/frontend/src/features/workflow-builder/components/WorkflowDesignerPane.tsx
@@ -15,7 +15,7 @@ import { ScheduleEditorDrawer } from '@/components/schedules/ScheduleEditorDrawe
 import { useToast } from '@/components/ui/use-toast';
 import { cn } from '@/lib/utils';
 import { useWorkflowUiStore } from '@/store/workflowUiStore';
-import { API_BASE_URL } from '@/services/api';
+import { API_V1_URL } from '@/services/api';
 
 // Custom hook to detect mobile viewport
 function useIsMobile(breakpoint = 768) {
@@ -93,7 +93,7 @@ export function WorkflowDesignerPane({
   const [webhooksPanelExpanded, setWebhooksPanelExpanded] = useState(false);
 
   // Default webhook URL for direct workflow invocation
-  const defaultWebhookUrl = workflowId ? `${API_BASE_URL}/api/v1/workflows/${workflowId}/run` : '';
+  const defaultWebhookUrl = workflowId ? `${API_V1_URL}/workflows/${workflowId}/run` : '';
 
   // Auto-open webhooks sidebar if navigated back with query param
   useEffect(() => {

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -87,6 +87,7 @@ function resolveApiBaseUrl() {
 }
 
 export const API_BASE_URL = resolveApiBaseUrl();
+export const API_V1_URL = `${API_BASE_URL}/api/v1`;
 
 // Helper function to get auth headers (reused by middleware and file operations)
 async function getAuthHeaders(): Promise<Record<string, string>> {
@@ -278,7 +279,7 @@ export const api = {
 
     resolvePorts: async (id: string, params: Record<string, unknown>) => {
       const headers = await getAuthHeaders();
-      const response = await fetch(`${API_BASE_URL}/api/v1/components/${id}/resolve-ports`, {
+      const response = await fetch(`${API_V1_URL}/components/${id}/resolve-ports`, {
         method: 'POST',
         headers: {
           ...headers,
@@ -582,7 +583,7 @@ export const api = {
       },
     ): Promise<TerminalChunkResponse> => {
       const headers = await getAuthHeaders();
-      const url = new URL(`${API_BASE_URL}/api/v1/workflows/runs/${executionId}/terminal`);
+      const url = new URL(`${API_V1_URL}/workflows/runs/${executionId}/terminal`);
       if (params?.nodeRef) url.searchParams.set('nodeRef', params.nodeRef);
       if (params?.stream) url.searchParams.set('stream', params.stream);
       if (params?.cursor) url.searchParams.set('cursor', params.cursor);
@@ -647,7 +648,7 @@ export const api = {
       if (options?.terminalCursor) params.set('terminalCursor', options.terminalCursor);
       if (options?.logCursor) params.set('logCursor', options.logCursor);
       const query = params.toString();
-      const url = `${API_BASE_URL}/api/v1/workflows/runs/${executionId}/stream${query ? `?${query}` : ''}`;
+      const url = `${API_V1_URL}/workflows/runs/${executionId}/stream${query ? `?${query}` : ''}`;
 
       // Build auth headers
       const headers: Record<string, string> = {};
@@ -794,7 +795,7 @@ export const api = {
 
     download: async (id: string): Promise<Blob> => {
       const headers = await getAuthHeaders();
-      const response = await fetch(`${API_BASE_URL}/api/v1/artifacts/${id}/download`, {
+      const response = await fetch(`${API_V1_URL}/artifacts/${id}/download`, {
         headers,
       });
       if (!response.ok) {
@@ -898,10 +899,6 @@ export const api = {
 
 export async function getApiAuthHeaders(): Promise<Record<string, string>> {
   return getAuthHeaders();
-}
-
-export function buildApiUrl(path: string): string {
-  return apiClient.buildUrl(path);
 }
 
 export default api;

--- a/frontend/src/store/webhookStore.ts
+++ b/frontend/src/store/webhookStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import type { WebhookConfiguration, WebhookDelivery } from '@shipsec/shared';
-import { API_BASE_URL } from '@/services/api';
+import { API_V1_URL } from '@/services/api';
 
 type WebhookStatusFilter = 'all' | 'active' | 'inactive';
 
@@ -93,7 +93,7 @@ export const useWebhookStore = create<WebhookStore>((set, get) => ({
     }
 
     try {
-      const response = await fetchWithHeaders(`${API_BASE_URL}/api/v1/webhooks/configurations`);
+      const response = await fetchWithHeaders(`${API_V1_URL}/webhooks/configurations`);
       if (!response.ok) {
         throw new Error('Failed to fetch webhooks');
       }
@@ -124,12 +124,9 @@ export const useWebhookStore = create<WebhookStore>((set, get) => ({
   },
 
   deleteWebhook: async (id: string) => {
-    const response = await fetchWithHeaders(
-      `${API_BASE_URL}/api/v1/webhooks/configurations/${id}`,
-      {
-        method: 'DELETE',
-      },
-    );
+    const response = await fetchWithHeaders(`${API_V1_URL}/webhooks/configurations/${id}`, {
+      method: 'DELETE',
+    });
     if (!response.ok) {
       throw new Error('Failed to delete webhook');
     }
@@ -152,7 +149,7 @@ export const useWebhookStore = create<WebhookStore>((set, get) => ({
 
   regeneratePath: async (id: string) => {
     const response = await fetchWithHeaders(
-      `${API_BASE_URL}/api/v1/webhooks/configurations/${id}/regenerate-path`,
+      `${API_V1_URL}/webhooks/configurations/${id}/regenerate-path`,
       {
         method: 'POST',
       },
@@ -173,13 +170,10 @@ export const useWebhookStore = create<WebhookStore>((set, get) => ({
   },
 
   testScript: async (dto) => {
-    const response = await fetchWithHeaders(
-      `${API_BASE_URL}/api/v1/webhooks/configurations/test-script`,
-      {
-        method: 'POST',
-        body: JSON.stringify(dto),
-      },
-    );
+    const response = await fetchWithHeaders(`${API_V1_URL}/webhooks/configurations/test-script`, {
+      method: 'POST',
+      body: JSON.stringify(dto),
+    });
     if (!response.ok) {
       throw new Error('Failed to test parsing script');
     }
@@ -193,7 +187,7 @@ export const useWebhookStore = create<WebhookStore>((set, get) => ({
 
     try {
       const response = await fetchWithHeaders(
-        `${API_BASE_URL}/api/v1/webhooks/configurations/${webhookId}/deliveries`,
+        `${API_V1_URL}/webhooks/configurations/${webhookId}/deliveries`,
       );
       if (!response.ok) {
         throw new Error('Failed to fetch deliveries');


### PR DESCRIPTION
## Overview
Fixes an issue where webhook URLs displayed in the frontend were missing the \`/api/v1\` global prefix, causing them to be incorrect.

## Changes
- Updated \`WorkflowDesignerPane.tsx\` to include \`/api/v1\` in the default webhook URL.
- Updated \`WorkflowNode.tsx\` to include \`/api/v1\` in the entry point workflow invoke URL.
- Updated \`WorkflowWebhooksPanel.tsx\` to include \`/api/v1\` in custom webhook URLs.

Fixes ENG-115