### PR TITLE
fix(ui): resolve multiple UI/UX issues - Fix sidebar stuck state when…

### DIFF
--- a/frontend/src/components/inputs/LeanSelect.tsx
+++ b/frontend/src/components/inputs/LeanSelect.tsx
@@ -101,8 +101,13 @@ export function LeanSelect({
             {clearable && value && !disabled && (
               <button
                 type="button"
+                onMouseDown={(e) => {
+                  // Prevent focus shift which can cause issues
+                  e.preventDefault();
+                }}
                 onClick={(e) => {
                   e.stopPropagation();
+                  e.preventDefault();
                   handleSelect(undefined);
                 }}
                 className="p-1 hover:bg-muted rounded-full text-muted-foreground hover:text-destructive transition-colors focus:outline-none focus:ring-2 focus:ring-destructive/20"
@@ -155,7 +160,11 @@ export function LeanSelect({
                   {clearable && value && (
                     <button
                       type="button"
-                      onClick={() => handleSelect(undefined)}
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        e.preventDefault();
+                        handleSelect(undefined);
+                      }}
                       className="w-full px-3 py-2 text-xs text-left text-muted-foreground hover:bg-destructive/5 hover:text-destructive transition-colors border-b border-muted/20"
                     >
                       Clear Selection

--- a/frontend/src/components/inputs/SecretSelect.tsx
+++ b/frontend/src/components/inputs/SecretSelect.tsx
@@ -12,7 +12,7 @@ import { LeanSelect, type SelectOption } from './LeanSelect';
 
 interface SecretSelectProps {
   value?: string;
-  onChange: (value: string) => void;
+  onChange: (value: string | undefined) => void;
   placeholder?: string;
   disabled?: boolean;
   className?: string;

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -271,7 +271,7 @@ export function TopBar({
       </Button>
 
       <div className="flex-1 min-w-0">
-        <div className="flex w-full gap-2 md:gap-4 items-center relative">
+        <div className="flex w-full gap-2 md:gap-4 items-center">
           {/* Workflow name - always visible, truncated on mobile, tappable to edit */}
           <div className="flex items-center justify-start gap-2 min-w-0 flex-shrink">
             <div
@@ -323,11 +323,12 @@ export function TopBar({
               </span>
             )}
           </div>
-          {/* Mode toggle - absolutely positioned to stay centered */}
-          <div className="absolute left-1/2 -translate-x-1/2 z-10">{modeToggle}</div>
-          {/* Spacer to push actions to the right */}
-          <div className="flex-1" />
-          <div className="flex items-center justify-end gap-1 md:gap-2 shrink-0">
+          {/* Mode toggle - flex-centered, won't overlap with other elements */}
+          <div className="flex-1 flex justify-center min-w-0">
+            <div className="flex-shrink-0">{modeToggle}</div>
+          </div>
+          {/* Actions on the right */}
+          <div className="flex items-center justify-end gap-1 md:gap-2 flex-shrink-0">
             <div className="flex items-center gap-1 md:gap-2">
               {mode === 'design' && (
                 <>

--- a/frontend/src/components/workflow/ConfigPanel.tsx
+++ b/frontend/src/components/workflow/ConfigPanel.tsx
@@ -855,7 +855,8 @@ export function ConfigPanel({
                             <SecretSelect
                               value={typeof manualValue === 'string' ? manualValue : ''}
                               onChange={(value) => {
-                                if (value === '') {
+                                // Handle both undefined (from clear button) and empty string
+                                if (value === undefined || value === '' || value === null) {
                                   handleInputOverrideChange(input.id, undefined);
                                 } else {
                                   handleInputOverrideChange(input.id, value);

--- a/frontend/src/features/workflow-builder/WorkflowBuilder.tsx
+++ b/frontend/src/features/workflow-builder/WorkflowBuilder.tsx
@@ -798,6 +798,14 @@ function WorkflowBuilderContent() {
 
       const key = event.key?.toLowerCase();
 
+      // Check if the active element is a text input (input, textarea, or contenteditable)
+      // If so, skip intercepting undo/redo to allow native browser behavior
+      const activeElement = document.activeElement;
+      const isTextInput =
+        activeElement instanceof HTMLInputElement ||
+        activeElement instanceof HTMLTextAreaElement ||
+        activeElement?.getAttribute('contenteditable') === 'true';
+
       // Save shortcut: Ctrl/Cmd + S
       const isSaveCombo = (event.metaKey || event.ctrlKey) && key === 's';
       if (isSaveCombo && mode === 'design') {
@@ -813,8 +821,9 @@ function WorkflowBuilderContent() {
       }
 
       // Undo shortcut: Ctrl/Cmd + Z (without Shift)
+      // Skip if user is typing in a text input to allow native undo
       const isUndoCombo = (event.metaKey || event.ctrlKey) && key === 'z' && !event.shiftKey;
-      if (isUndoCombo && mode === 'design') {
+      if (isUndoCombo && mode === 'design' && !isTextInput) {
         event.preventDefault();
         event.stopPropagation();
         if (canUndo) {
@@ -824,10 +833,11 @@ function WorkflowBuilderContent() {
       }
 
       // Redo shortcut: Ctrl/Cmd + Shift + Z OR Ctrl/Cmd + Y
+      // Skip if user is typing in a text input to allow native redo
       const isRedoCombo =
         ((event.metaKey || event.ctrlKey) && event.shiftKey && key === 'z') ||
         ((event.metaKey || event.ctrlKey) && key === 'y');
-      if (isRedoCombo && mode === 'design') {
+      if (isRedoCombo && mode === 'design' && !isTextInput) {
         event.preventDefault();
         event.stopPropagation();
         if (canRedo) {


### PR DESCRIPTION
# Summary

This PR fixes 4 critical UI/UX issues reported in the Studio interface, improving sidebar behavior, secret selection, layout responsiveness, and keyboard shortcuts.

Issues Fixed
1. Sidebar Stuck When Opening Link in New Tab (CMD+Click)
Problem: The sidebar would expand and get stuck in an "open" state when a user CMD+clicked a link (e.g., "Secrets") to open it in a new tab. This happened because the click event triggered the route change logic before the browser opened the new tab. Solution:

Added a check in the navigation onClick handler to ignore state updates if modifier keys (CMD, Ctrl, Shift) are pressed.
Added event listeners (blur, visibilitychange) to auto-collapse the sidebar if the window loses focus while hovering. File: src/components/layout/AppLayout.tsx

2. Secret Selection Clearing Issue
Problem: Clicking the clear (X) button or "Clear Selection" in a secret dropdown did not clear the value. The selection would momentarily clear and then immediately revert to the previous value. Root Cause:

SecretSelect
 onChange prop type was too strict (string instead of string | undefined).
ParameterField
 had an auto-migration useEffect that treated undefined as an invalid value and automatically re-selected the first available secret. Solution:
Updated 
SecretSelect
 to accept undefined in onChange.
Added stopPropagation and preventDefault to partial-fix focus issues in dropdown.
Modified the auto-migration logic in 
ParameterField
 to ONLY run for non-empty string values (legacy name references), preventing it from overriding intentional clears. Files: 
src/components/inputs/SecretSelect.tsx
, 
src/components/inputs/LeanSelect.tsx
, 
src/components/workflow/ParameterField.tsx
, 
src/components/workflow/ConfigPanel.tsx

3. TopBar Layout Overlap
Problem: The Design/Execute toggle and action buttons overlapped or misaligned when the sidebar opened/closed because of absolute positioning. Solution: Refactored the TopBar layout to use Flexbox (flex-1, justify-center) instead of absolute positioning (left-1/2), ensuring components flow correctly without overlap regardless of available width. File: src/components/layout/TopBar.tsx

4. Text Input Undo/Redo Conflict
Problem: Pressing Cmd+Z/Cmd+Shift+Z while editing text inputs (e.g., node names) triggered the workflow graph undo/redo instead of the browser's native text undo. Solution: Added a check in the global keyboard handler to skip custom undo/redo logic if the active element is a text input, textarea, or contenteditable. File: src/features/workflow-builder/WorkflowBuilder.tsx

# Testing
- [ ] `bun run test`
- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [ ] Additional notes:

# Documentation
- [ ] Updated the relevant doc(s) (see `docs/guide.md`) or checked that no updates are needed.
- [ ] Recorded contract/architecture changes in both public docs and `.ai` logs when applicable.
