### PR TITLE
fix: nodes can not be deleted in execution tab

### DIFF
--- a/frontend/src/components/workflow/Canvas.tsx
+++ b/frontend/src/components/workflow/Canvas.tsx
@@ -338,18 +338,18 @@ export function Canvas({
         nextNodes = nodes.map((node) =>
           node.id === params.target
             ? {
-              ...node,
-              data: {
-                ...node.data,
-                inputs: {
-                  ...(node.data.inputs as Record<string, unknown>),
-                  [targetHandle]: {
-                    source: params.source,
-                    output: params.sourceHandle,
-                  },
-                } as Record<string, unknown>,
-              },
-            }
+                ...node,
+                data: {
+                  ...node.data,
+                  inputs: {
+                    ...(node.data.inputs as Record<string, unknown>),
+                    [targetHandle]: {
+                      source: params.source,
+                      output: params.sourceHandle,
+                    },
+                  } as Record<string, unknown>,
+                },
+              }
             : node,
         );
         setNodes(nextNodes);
@@ -1042,7 +1042,7 @@ export function Canvas({
                     onScheduleAction={resolvedOnScheduleAction}
                     onScheduleDelete={resolvedOnScheduleDelete}
                     onViewSchedules={resolvedOnViewSchedules}
-                    onWidthChange={() => { }} // Not resizable on mobile
+                    onWidthChange={() => {}} // Not resizable on mobile
                   />
                 </div>,
                 document.getElementById('mobile-bottom-sheet-portal') || document.body,


### PR DESCRIPTION
# Summary
- the user could delete the canvas and delete the connection in execution tab. Now, it is not allowed and the canvas and nodes are immutable. It is only allowed in design tab.

# Testing
- [ ] `bun run test`
- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [ ] Additional notes:

# Documentation
- [ ] Updated the relevant doc(s) (see `docs/guide.md`) or checked that no updates are needed.
- [ ] Recorded contract/architecture changes in both public docs and `.ai` logs when applicable.
