### PR TITLE
fix: added scrollbar in the timeline component

### DIFF
--- a/frontend/src/components/timeline/ExecutionInspector.tsx
+++ b/frontend/src/components/timeline/ExecutionInspector.tsx
@@ -354,7 +354,7 @@ export function ExecutionInspector({ onRerunRun }: ExecutionInspectorProps = {})
           style={{ height: timelineHeight }}
         >
           {selectedRun ? (
-            <div className="h-full overflow-hidden">
+            <div className="h-full overflow-y-auto">
               <ExecutionTimeline />
             </div>
           ) : (

--- a/frontend/src/components/timeline/ExecutionTimeline.tsx
+++ b/frontend/src/components/timeline/ExecutionTimeline.tsx
@@ -305,7 +305,7 @@ export function ExecutionTimeline() {
   }
 
   return (
-    <div className="border-t bg-background">
+    <div className="border-t bg-background overflow-y-auto max-h-full">
       <div className="p-4 space-y-4">
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-4">


### PR DESCRIPTION
# Summary
Issue: When the lower panel (timeline view) is pulled up/resized to be taller, the content gets cut off with no way to scroll through it.

Solution:
Changed overflow-hidden to overflow-y-auto in the timeline wrapper in ExecutionInspector.tsx (line 357)
Added overflow-y-auto max-h-full to the main container in ExecutionTimeline.tsx (line 308)
Now when users resize the timeline panel, a vertical scrollbar will appear if the content exceeds the visible area, making it more user-friendly.

# Testing
- [ ] `bun run test`
- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [ ] Additional notes:

# Documentation
- [ ] Updated the relevant doc(s) (see `docs/guide.md`) or checked that no updates are needed.
- [ ] Recorded contract/architecture changes in both public docs and `.ai` logs when applicable.
