### PR TITLE
feat: Support multiple dynamic inputs in Console Log component

### DIFF
--- a/worker/src/temporal/workflow-runner.ts
+++ b/worker/src/temporal/workflow-runner.ts
@@ -272,8 +272,17 @@ export async function executeWorkflow(
         inputs: maskSecretOutputs(inputPorts, inputs) as Record<string, unknown>,
       });
 
-      const parsedInputs = component.inputs.parse(inputs);
       const parsedParams = component.parameters ? component.parameters.parse(params) : params;
+
+      // For components with dynamic ports (resolvePorts), resolve the actual input schema
+      let inputsSchema = component.inputs;
+      if (typeof component.resolvePorts === 'function') {
+        const resolved = component.resolvePorts(parsedParams);
+        if (resolved?.inputs) {
+          inputsSchema = resolved.inputs;
+        }
+      }
+      const parsedInputs = inputsSchema.parse(inputs);
 
       // Create execution context with SDK interfaces
       const scopedArtifacts = options.artifacts


### PR DESCRIPTION
# Summary
Issue: The Console Log component only accepted a single data input, making it cumbersome to log outputs from multiple components. Users had to add multiple Console Log nodes to debug different parts of their workflow.

Solution: Updated Console Log to support multiple named input fields :
- Added variables parameter with variable-list editor to define custom input fields
- Implemented resolvePorts() to dynamically create input ports based on user-defined variables
- Each variable can have a name (port ID) and optional label (display name)
- Default data and label inputs remain available for backward compatibility
- All connected inputs are logged with their labels for easy identification

Additional Fix: Fixed a bug in workflow-runner.ts where resolvePorts() wasn't being called for components with dynamic inputs, causing input parsing to fail.

Version: Bumped to 2.0.0


# Testing
- [ ] `bun run test`
- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [ ] Additional notes:

# Documentation
- [ ] Updated the relevant doc(s) (see `docs/guide.md`) or checked that no updates are needed.
- [ ] Recorded contract/architecture changes in both public docs and `.ai` logs when applicable.
