### PR TITLE
fix: spotlight component placement not working on canvas click

### DIFF
--- a/frontend/src/components/layout/sidebar-state.ts
+++ b/frontend/src/components/layout/sidebar-state.ts
@@ -1,19 +1,76 @@
-// Global state for mobile component placement (shared between Sidebar and Canvas)
+import { create } from 'zustand';
+
+interface PlacementState {
+  componentId: string | null;
+  componentName: string | null;
+  isActive: boolean;
+  // Scope placement to a specific workflow ID
+  workflowId: string | null;
+}
+
+interface PlacementActions {
+  setPlacement: (componentId: string, componentName: string, workflowId: string | null) => void;
+  clearPlacement: () => void;
+  // Check if placement is active for a specific workflow
+  isPlacementActiveForWorkflow: (workflowId: string | null) => boolean;
+}
+
+/**
+ * Component Placement Store
+ * Manages the state for placing components on the canvas via spotlight/sidebar.
+ * Placement is scoped to a specific workflow to avoid cross-workflow interference.
+ */
+export const usePlacementStore = create<PlacementState & PlacementActions>((set, get) => ({
+  componentId: null,
+  componentName: null,
+  isActive: false,
+  workflowId: null,
+
+  setPlacement: (componentId, componentName, workflowId) => {
+    set({
+      componentId,
+      componentName,
+      isActive: true,
+      workflowId,
+    });
+  },
+
+  clearPlacement: () => {
+    set({
+      componentId: null,
+      componentName: null,
+      isActive: false,
+      workflowId: null,
+    });
+  },
+
+  isPlacementActiveForWorkflow: (workflowId) => {
+    const state = get();
+    // For new workflows (null ID), match if placement workflowId is also null
+    // For existing workflows, match by ID
+    return state.isActive && state.workflowId === workflowId;
+  },
+}));
+
+// Legacy exports for backward compatibility during migration
+// TODO: Remove these after all usages are migrated to usePlacementStore
 export const mobilePlacementState = {
-  componentId: null as string | null,
-  componentName: null as string | null,
-  isActive: false, // True when a component is selected and waiting to be placed
-  onSidebarClose: null as (() => void) | null, // Callback to close sidebar
+  get componentId() {
+    return usePlacementStore.getState().componentId;
+  },
+  get componentName() {
+    return usePlacementStore.getState().componentName;
+  },
+  get isActive() {
+    return usePlacementStore.getState().isActive;
+  },
+  onSidebarClose: null as (() => void) | null,
 };
 
-// Function to set the sidebar close callback
 export const setMobilePlacementSidebarClose = (callback: () => void) => {
   mobilePlacementState.onSidebarClose = callback;
 };
 
-// Function to clear the placement state
 export const clearMobilePlacement = () => {
-  mobilePlacementState.componentId = null;
-  mobilePlacementState.componentName = null;
-  mobilePlacementState.isActive = false;
+  usePlacementStore.getState().clearPlacement();
 };

--- a/frontend/src/features/command-palette/CommandPalette.tsx
+++ b/frontend/src/features/command-palette/CommandPalette.tsx
@@ -6,7 +6,8 @@ import { useCommandPaletteStore } from '@/store/commandPaletteStore';
 import { useThemeStore } from '@/store/themeStore';
 import { useComponentStore } from '@/store/componentStore';
 import { useWorkflowUiStore } from '@/store/workflowUiStore';
-import { mobilePlacementState } from '@/components/layout/sidebar-state';
+import { useWorkflowStore } from '@/store/workflowStore';
+import { usePlacementStore } from '@/components/layout/sidebar-state';
 import { api } from '@/services/api';
 import { cn } from '@/lib/utils';
 import {
@@ -185,6 +186,9 @@ export function CommandPalette() {
   }, [storeComponents]);
 
   // Handle component placement
+  const setPlacement = usePlacementStore((state) => state.setPlacement);
+  const currentWorkflowId = useWorkflowStore((state) => state.metadata.id);
+
   const handleComponentSelect = useCallback(
     (component: ComponentMetadata) => {
       // If not on workflow page, navigate to new workflow first
@@ -195,19 +199,14 @@ export function CommandPalette() {
         return;
       }
 
-      // Set up mobile placement state (works for both mobile and desktop now)
-      // The canvas will detect this and place the component
-      mobilePlacementState.componentId = component.id;
-      mobilePlacementState.componentName = component.name;
-      mobilePlacementState.isActive = true;
+      // Set up placement state scoped to the current workflow
+      // The canvas will detect this and place the component when clicked
+      setPlacement(component.id, component.name, currentWorkflowId);
 
       // Close the command palette
       close();
-
-      // For desktop, we could also trigger a center placement, but the "click to place"
-      // gives users more control over where the component goes
     },
-    [isOnWorkflowPage, isOnNewWorkflowPage, navigate, close],
+    [isOnWorkflowPage, isOnNewWorkflowPage, navigate, close, setPlacement, currentWorkflowId],
   );
 
   // Build static commands


### PR DESCRIPTION
# Summary
- Fix spotlight component placement not responding to canvas clicks
- Add workflow-scoped placement state to prevent cross-workflow interference
- Improve UX with crosshair cursor during placement mode

Problem
- When selecting a component from the spotlight (Cmd+K), the "Click to place" indicator wasn't appearing immediately, and clicking on the canvas didn't place the component. Additionally, the placement state was global, meaning selecting a component in one workflow would affect all open workflows.

Root Cause
- No re-render on state change: The placement state was a plain JavaScript object instead of React state. When the Command Palette set the placement values, React didn't re-render the Canvas component, so the indicator wasn't visible.
- Wrong click handler: The placement logic was in handleCanvasTap attached to an outer div, but ReactFlow captures all click events internally. The actual onPaneClick handler (which fires when clicking empty canvas space) only deselected nodes.
- Global state: The placement was stored globally with no workflow scoping.

Fix
- Converted sidebar-state.ts from a plain object to a Zustand store (usePlacementStore) for proper React reactivity
- Added workflowId to placement state to scope placement to specific workflows
- Integrated placement logic into ReactFlow's onPaneClick handler
- Added crosshair cursor when placement mode is active for better visual feedback
- Updated text from "Tap to place" to "Click to place" for desktop clarity

# Testing
- [ ] `bun run test`
- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [ ] Additional notes:

# Documentation
- [ ] Updated the relevant doc(s) (see `docs/guide.md`) or checked that no updates are needed.
- [ ] Recorded contract/architecture changes in both public docs and `.ai` logs when applicable.
