### PR TITLE
fix(docker): build workspace packages before frontend in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -103,6 +103,9 @@ ENV VITE_PUBLIC_POSTHOG_HOST=${VITE_PUBLIC_POSTHOG_HOST}
 USER shipsec
 WORKDIR /app/frontend
 
+# Build TypeScript declarations for workspace packages first (project references require this)
+RUN cd /app && bunx tsc --build packages/shared packages/backend-client
+
 # Build production assets ahead of time so Vite embeds the env vars
 RUN bun run build
 


### PR DESCRIPTION
## Summary
- Fixes the release pipeline which has been broken since Jan 19 (commit f9ee4a3b)
- Adds a step to build TypeScript declarations for workspace packages before the frontend build

## Problem
The frontend's `tsconfig.json` uses TypeScript project references to `packages/shared` and `packages/backend-client`. Since commit f9ee4a3b ("fast typecheck test") enabled composite builds for faster type checking, these packages must be built before the frontend can compile.

The `dist/` folders are gitignored and don't exist in fresh Docker builds, causing TS6305 errors like:
```
error TS6305: Output file '/app/packages/shared/dist/index.d.ts' has not been built from source file '/app/packages/shared/src/index.ts'.
```

## Solution
Added `RUN cd /app && bunx tsc --build packages/shared packages/backend-client` before the frontend build step in the Dockerfile.

## Test plan
- [x] Verified locally by clearing all dist folders and running the same build sequence
- [x] Tested all three Docker targets locally:
  - `docker build --target backend -t studio-backend:test .` ✅
  - `docker build --target worker -t studio-worker:test .` ✅
  - `docker build --target frontend -t studio-frontend:test .` ✅