### PR TITLE
chore(db,docker): squash migration and compose config commits

### DIFF
--- a/backend/drizzle/0019_migrate-error-to-jsonb.sql
+++ b/backend/drizzle/0019_migrate-error-to-jsonb.sql
@@ -1,0 +1,39 @@
+-- Migration: Convert workflow_traces.error from TEXT to JSONB
+-- Required for: Structured error representation (commit c7282f9d)
+-- Note: This migration preserves existing JSON text by parsing it, with fallback for plain text
+-- Safe to run on databases that already have JSONB (will be a no-op)
+
+-- Helper function to safely parse JSON text, falling back to wrapping as JSON string
+CREATE OR REPLACE FUNCTION pg_temp.try_parse_jsonb(text_value TEXT) RETURNS JSONB AS $$
+BEGIN
+    IF text_value IS NULL THEN
+        RETURN NULL;
+    END IF;
+    -- Try to parse as JSON
+    RETURN text_value::jsonb;
+EXCEPTION WHEN OTHERS THEN
+    -- If parsing fails, wrap the plain text as a JSON string
+    RETURN to_jsonb(text_value);
+END;
+$$ LANGUAGE plpgsql IMMUTABLE;
+
+DO $$
+BEGIN
+    -- Check if the column is still TEXT type
+    IF EXISTS (
+        SELECT 1
+        FROM information_schema.columns
+        WHERE table_name = 'workflow_traces'
+        AND column_name = 'error'
+        AND data_type = 'text'
+    ) THEN
+        -- Convert TEXT to JSONB, parsing existing JSON text or wrapping plain text
+        ALTER TABLE workflow_traces
+        ALTER COLUMN error TYPE jsonb
+        USING pg_temp.try_parse_jsonb(error);
+
+        RAISE NOTICE 'Successfully migrated workflow_traces.error from TEXT to JSONB';
+    ELSE
+        RAISE NOTICE 'workflow_traces.error is already JSONB or does not exist, skipping migration';
+    END IF;
+END $$;

--- a/backend/drizzle/meta/_journal.json
+++ b/backend/drizzle/meta/_journal.json
@@ -85,6 +85,13 @@
       "when": 1738200000000,
       "tag": "0015_create-workflow-schedules",
       "breakpoints": true
+    },
+    {
+      "idx": 12,
+      "version": "7",
+      "when": 1738454400000,
+      "tag": "0019_migrate-error-to-jsonb",
+      "breakpoints": true
     }
   ]
 }

--- a/docker/docker-compose.full.yml
+++ b/docker/docker-compose.full.yml
@@ -9,12 +9,12 @@ services:
       POSTGRES_DB: shipsec
       POSTGRES_MULTIPLE_DATABASES: temporal
     ports:
-      - "5433:5432"
+      - '5433:5432'
     volumes:
       - postgres_data:/var/lib/postgresql/data
       - ./init-db:/docker-entrypoint-initdb.d
     healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U shipsec"]
+      test: ['CMD-SHELL', 'pg_isready -U shipsec']
       interval: 5s
       timeout: 3s
       retries: 10
@@ -35,12 +35,12 @@ services:
       - POSTGRES_SEEDS=postgres
       - AUTO_SETUP=true
     ports:
-      - "7233:7233"
+      - '7233:7233'
     volumes:
       - temporal_data:/var/lib/temporal
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "tctl", "--address", "localhost:7233", "cluster", "health"]
+      test: ['CMD', 'tctl', '--address', 'localhost:7233', 'cluster', 'health']
       interval: 30s
       timeout: 10s
       retries: 5
@@ -52,12 +52,12 @@ services:
       - TEMPORAL_ADDRESS=temporal:7233
       - TEMPORAL_NAMESPACE=default
     ports:
-      - "8081:8080"
+      - '8081:8080'
     depends_on:
       - temporal
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080"]
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080']
       interval: 30s
       timeout: 10s
       retries: 5
@@ -70,13 +70,13 @@ services:
       MINIO_ROOT_USER: minioadmin
       MINIO_ROOT_PASSWORD: minioadmin
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - '9000:9000'
+      - '9001:9001'
     volumes:
       - minio_data:/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9000/minio/health/live"]
+      test: ['CMD', 'curl', '-f', 'http://localhost:9000/minio/health/live']
       interval: 30s
       timeout: 10s
       retries: 5
@@ -86,13 +86,13 @@ services:
     container_name: shipsec-loki
     command: -config.file=/etc/loki/local-config.yaml
     ports:
-      - "3100:3100"
+      - '3100:3100'
     volumes:
       - ./loki/loki-config.yaml:/etc/loki/local-config.yaml
       - loki_data:/loki
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3100/ready"]
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:3100/ready']
       interval: 30s
       timeout: 10s
       retries: 5
@@ -101,12 +101,12 @@ services:
     image: redis:latest
     container_name: shipsec-redis
     ports:
-      - "6379:6379"
+      - '6379:6379'
     volumes:
       - redis_data:/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "redis-cli", "ping"]
+      test: ['CMD', 'redis-cli', 'ping']
       interval: 30s
       timeout: 10s
       retries: 5
@@ -125,13 +125,13 @@ services:
       - --check=false
       - --advertise-kafka-addr=redpanda:9092
     ports:
-      - "9092:9092"
-      - "9644:9644"
+      - '9092:9092'
+      - '9644:9644'
     volumes:
       - redpanda_data:/var/lib/redpanda/data
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:9644/v1/status/ready"]
+      test: ['CMD', 'curl', '-f', 'http://localhost:9644/v1/status/ready']
       interval: 30s
       timeout: 10s
       retries: 5
@@ -144,7 +144,7 @@ services:
     environment:
       CONFIG_FILEPATH: /etc/redpanda/console-config.yaml
     ports:
-      - "8082:8080"
+      - '8082:8080'
     volumes:
       - ./redpanda-console-config.yaml:/etc/redpanda/console-config.yaml:ro
     restart: unless-stopped
@@ -154,13 +154,13 @@ services:
     image: docker:27-dind
     container_name: shipsec-dind
     privileged: true
-    command: ["--host=tcp://0.0.0.0:2375", "--storage-driver=overlay2"]
+    command: ['--host=tcp://0.0.0.0:2375', '--storage-driver=overlay2']
     environment:
       - DOCKER_TLS_CERTDIR=
     volumes:
       - docker_data:/var/lib/docker
     healthcheck:
-      test: ["CMD", "docker", "info"]
+      test: ['CMD', 'docker', 'info']
       interval: 30s
       timeout: 10s
       retries: 5
@@ -200,8 +200,10 @@ services:
       - CLERK_SECRET_KEY=
       # Set to 'true' to disable analytics
       - DISABLE_ANALYTICS=${DISABLE_ANALYTICS:-false}
+      # Secret encryption key (32-byte hex string)
+      - SECRET_STORE_MASTER_KEY=${SECRET_STORE_MASTER_KEY:-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef}
     ports:
-      - "3211:3211"
+      - '3211:3211'
     depends_on:
       postgres:
         condition: service_healthy
@@ -236,12 +238,12 @@ services:
       - VITE_DEFAULT_ORG_ID=local-dev
       - VITE_CLERK_PUBLISHABLE_KEY=
     ports:
-      - "8090:8080"
+      - '8090:8080'
     depends_on:
       - backend
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080"]
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080']
       interval: 30s
       timeout: 10s
       retries: 5
@@ -273,6 +275,8 @@ services:
       - LOG_KAFKA_CLIENT_ID=shipsec-worker
       - EVENT_KAFKA_TOPIC=telemetry.events
       - EVENT_KAFKA_CLIENT_ID=shipsec-worker-events
+      # Secret encryption key (32-byte hex string)
+      - SECRET_STORE_MASTER_KEY=${SECRET_STORE_MASTER_KEY:-0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef}
     depends_on:
       postgres:
         condition: service_healthy
@@ -288,7 +292,7 @@ services:
         condition: service_healthy
     restart: unless-stopped
     healthcheck:
-      test: ["CMD", "node", "-e", "process.exit(0)"]
+      test: ['CMD', 'node', '-e', 'process.exit(0)']
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## Summary
- Add migration for workflow_traces.error field from TEXT to JSONB for better error data structure and querying
- Add SECRET_STORE_MASTER_KEY environment variable to docker-compose for secret encryption support

## Why these changes?
1. **workflow_traces.error migration**: The error field needs to store structured JSON data (stack traces, error metadata) rather than plain text. JSONB enables better querying and indexing of error information.

2. **SECRET_STORE_MASTER_KEY**: Required for encrypting sensitive data (API keys, credentials) stored in the secret store. Without this key, the secret encryption/decryption functionality won't work in Docker deployments.

## Test plan
- [ ] Verify migration runs successfully on existing database
- [ ] Verify docker compose starts with new SECRET_STORE_MASTER_KEY config
- [ ] Test secret store encryption/decryption works with the key