### PR TITLE
fix(docker): use curl instead of wget for frontend health check

### DIFF
--- a/docker/docker-compose.full.yml
+++ b/docker/docker-compose.full.yml
@@ -243,7 +243,7 @@ services:
       - backend
     restart: unless-stopped
     healthcheck:
-      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:8080']
+      test: ['CMD', 'curl', '-f', 'http://localhost:8080']
       interval: 30s
       timeout: 10s
       retries: 5


### PR DESCRIPTION
## Summary
- Frontend health check was showing unhealthy due to `wget` not being installed in the bun/oven-based image
- Changed health check to use `curl` which is available in the image

## Test plan
- [x] Deployed to studio server and verified frontend now shows healthy