### PR TITLE
fix(deploy): show version tag with commit hash in UI

### DIFF
--- a/justfile
+++ b/justfile
@@ -185,13 +185,14 @@ prod action="start":
         build)
             echo "🔨 Building and starting production..."
 
-            # Auto-detect git version: prioritize tag, then SHA, then "dev"
-            GIT_TAG=$(git describe --exact-match --tags 2>/dev/null || echo "")
+            # Auto-detect git version: combine tag and SHA for display
+            GIT_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
+            GIT_COMMIT=$(git rev-parse --short=7 HEAD 2>/dev/null || echo "dev")
             if [ -n "$GIT_TAG" ]; then
-                export GIT_SHA="$GIT_TAG"
-                echo "📌 Building with tag: $GIT_SHA"
+                export GIT_SHA="${GIT_TAG} (${GIT_COMMIT})"
+                echo "📌 Building with version: $GIT_SHA"
             else
-                export GIT_SHA=$(git rev-parse --short=7 HEAD 2>/dev/null || echo "dev")
+                export GIT_SHA="$GIT_COMMIT"
                 echo "📌 Building with commit: $GIT_SHA"
             fi
 


### PR DESCRIPTION
## Summary
- Display version as `v0.2 (e73fd1b)` instead of just the tag or SHA
- Makes it easier to identify both the release version and exact commit

## Changes
- Updated `justfile` to combine tag and commit hash for `GIT_SHA` build arg
- Uses format `${GIT_TAG} (${GIT_COMMIT})` when a tag exists