### PR TITLE
fix : when importing the workflow, it automatically check if secret exist.

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
         "chalk": "^5.6.2",
         "chalk-animation": "^2.0.3",
         "long": "^5.3.2",
+        "zod": "^4.3.6",
       },
       "devDependencies": {
         "@ai-sdk/mcp": "^1.0.13",

--- a/package.json
+++ b/package.json
@@ -51,9 +51,9 @@
     "undici": "^7.19.0"
   },
   "lint-staged": {
-    "frontend/**/*.{ts,tsx,js,jsx}": "bunx eslint --fix --config frontend/eslint.config.mjs",
-    "backend/**/*.{ts,js}": "bunx eslint --fix --config backend/eslint.config.mjs",
-    "worker/**/*.{ts,js}": "bunx eslint --fix --config worker/eslint.config.mjs",
+    "frontend/**/*.{ts,tsx,js,jsx}": "bunx eslint@9 --fix --config frontend/eslint.config.mjs",
+    "backend/**/*.{ts,js}": "bunx eslint@9 --fix --config backend/eslint.config.mjs",
+    "worker/**/*.{ts,js}": "bunx eslint@9 --fix --config worker/eslint.config.mjs",
     "*.{json,md,yml,yaml}": "bunx prettier --write"
   },
   "dependencies": {
@@ -61,6 +61,7 @@
     "@grpc/grpc-js": "^1.14.3",
     "chalk": "^5.6.2",
     "chalk-animation": "^2.0.3",
-    "long": "^5.3.2"
+    "long": "^5.3.2",
+    "zod": "^4.3.6"
   }
 }


### PR DESCRIPTION
…s for the secret

# Summary
When you export a workflow from one environment and import it into another, the Secret IDs (references to secure credentials) travel with the JSON file. available in the new environment.
If the secret exists: It works fine.
If the secret is missing: The component would still hold onto that old "Reference ID," causing the UI to show a broken or confusing state where it looks like a secret is selected but it's actually invalid (or just a random ID string).

The Solution
We implemented a validation step during the import process in useWorkflowImportExport.ts
- Check Availability: Before loading the workflow onto the canvas, we now fetch the current user's list of available secrets.
- Validate References: We loop through every node in the imported workflow, identify which parameters are "secrets" (based on their component definition), and check the value.
- Sanitize:
1. If the Secret Exists: We keep the reference. It will show up correctly as a working secret.
2. If the Secret matches a referenced ID but is NOT found: We automatically remove the reference (delete the value). This ensures the field appears "empty" in the component settings, prompting the user to select a valid secret instead of showing a broken ID.

# Testing
- [ ] `bun run test`
- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [ ] Additional notes:

# Documentation
- [ ] Updated the relevant doc(s) (see `docs/guide.md`) or checked that no updates are needed.
- [ ] Recorded contract/architecture changes in both public docs and `.ai` logs when applicable.
