### PR TITLE
fix(ui): enhance spotlight command palette selection visibility

### DIFF
--- a/frontend/src/features/command-palette/CommandPalette.tsx
+++ b/frontend/src/features/command-palette/CommandPalette.tsx
@@ -576,8 +576,10 @@ export function CommandPalette() {
                       onClick={() => executeCommand(command)}
                       onMouseEnter={() => setSelectedIndex(flatIndex)}
                       className={cn(
-                        'w-full flex items-center gap-3 px-4 py-2.5 text-left transition-colors duration-75',
-                        isSelected ? 'bg-accent text-accent-foreground' : 'hover:bg-accent/50',
+                        'w-full flex items-center gap-3 px-3 py-2.5 pl-3 border-l-2 text-left transition-colors duration-75',
+                        isSelected
+                          ? 'bg-primary/10 border-primary text-foreground'
+                          : 'hover:bg-accent/50 border-transparent text-muted-foreground',
                         isComponent && !canPlaceComponents && 'opacity-50',
                       )}
                       disabled={isComponent && !canPlaceComponents}
@@ -597,7 +599,7 @@ export function CommandPalette() {
                           <Icon
                             className={cn(
                               'w-4 h-4',
-                              isSelected ? 'text-accent-foreground' : 'text-muted-foreground',
+                              isSelected ? 'text-primary' : 'text-muted-foreground',
                             )}
                           />
                         ) : null}
@@ -608,16 +610,14 @@ export function CommandPalette() {
                           <div
                             className={cn(
                               'text-xs truncate',
-                              isSelected ? 'text-accent-foreground/70' : 'text-muted-foreground',
+                              isSelected ? 'text-muted-foreground' : 'text-muted-foreground',
                             )}
                           >
                             {command.description}
                           </div>
                         )}
                       </div>
-                      {isSelected && (
-                        <ArrowRight className="w-4 h-4 flex-shrink-0 text-muted-foreground" />
-                      )}
+                      {isSelected && <ArrowRight className="w-4 h-4 flex-shrink-0 text-primary" />}
                     </button>
                   );
                 })}


### PR DESCRIPTION
# Summary
## Issue
The selection highlight in the Spotlight (Command Palette) was previously too subtle, relying only on a faint background change (`bg-accent`). This made it difficult for users to distinguish the currently selected item, particularly in light mode or on screens with lower contrast.

## Solution
This PR improves the visual feedback for the selected item in the Command Palette by:
- **Background Tint:** Applying a `primary/10` background color to the selected row, providing a clear but non-overwhelming highlight.
- **Left Border Indicator:** Adding a `2px` solid primary-colored left border (`border-l-2`) to the selected item, creating a distinct visual anchor.
- **Icon Highlighting:** Changing the color of the leading icon and the trailing arrow to the primary color when selected.
- **Layout Stability:** Ensuring unselected items maintain a transparent border to prevent any layout shifts when navigating through the list.

These changes ensure that the user's focus is immediately apparent even when quickly navigating the command palette.

# Testing
- [ ] `bun run test`
- [ ] `bun run lint`
- [ ] `bun run typecheck`
- [ ] Additional notes:

# Documentation
- [ ] Updated the relevant doc(s) (see `docs/guide.md`) or checked that no updates are needed.
- [ ] Recorded contract/architecture changes in both public docs and `.ai` logs when applicable.
