### PR TITLE
fix(dev): bash 3.2 compatibility for dev-instance-manager.sh

### DIFF
--- a/scripts/dev-instance-manager.sh
+++ b/scripts/dev-instance-manager.sh
@@ -7,11 +7,9 @@ set -euo pipefail
 # Configuration
 INSTANCES_DIR=".instances"
 
-# Base port mappings
-declare -A BASE_PORTS=(
-  [FRONTEND]=5173
-  [BACKEND]=3211
-)
+# Base port mappings (plain variables for bash 3.2 compatibility on macOS)
+BASE_PORT_FRONTEND=5173
+BASE_PORT_BACKEND=3211
 
 # Colors for output
 RED='\033[0;31m'
@@ -45,13 +43,17 @@ get_instance_dir() {
 get_port() {
   local port_name=$1
   local instance=$2
-  local base_port="${BASE_PORTS[$port_name]}"
-  
-  if [[ -z "$base_port" ]]; then
-    log_error "Unknown port: $port_name"
-    return 1
-  fi
-  
+  local base_port=""
+
+  case "$port_name" in
+    FRONTEND) base_port=$BASE_PORT_FRONTEND ;;
+    BACKEND)  base_port=$BASE_PORT_BACKEND ;;
+    *)
+      log_error "Unknown port: $port_name"
+      return 1
+      ;;
+  esac
+
   # Port offset: instance N uses base_port + N*100
   echo $((base_port + instance * 100))
 }


### PR DESCRIPTION
## Summary
- Replaces `declare -A` (associative arrays, bash 4+ only) with plain variables and a `case` statement in `scripts/dev-instance-manager.sh`
- macOS (even `macOS Tahoe Version 26.2` ) ships with bash 3.2 by default, which caused `just dev` to fail with `unbound variable` errors
- No functional changes — same port mappings and behavior, just compatible with all bash versions
- 

Resolves ENG-177

## Test plan
- [x] Run `just dev` on macOS with default bash 3.2 and confirm it starts without errors
- [x] Run `just dev` on a system with bash 5+ and confirm it still works
- [x] Verify port assignments remain correct (FRONTEND=5173, BACKEND=3211 for instance 0)