### PR TITLE
fix(worker): use deterministic volume naming for workflow execution

### DIFF
--- a/worker/src/utils/isolated-volume.ts
+++ b/worker/src/utils/isolated-volume.ts
@@ -51,6 +51,19 @@ export class IsolatedContainerVolume {
   }
 
   /**
+   * Derives the deterministic volume name for a given tenant and run.
+   * Downstream components can use this to reference an existing volume
+   * created by an upstream component in the same workflow execution.
+   *
+   * @param tenantId - Tenant identifier
+   * @param runId - Unique run/execution identifier
+   * @returns The volume name (e.g., `tenant-foo-run-bar`)
+   */
+  static deriveVolumeName(tenantId: string, runId: string): string {
+    return `tenant-${tenantId}-run-${runId}`;
+  }
+
+  /**
    * Creates the isolated volume and populates it with files.
    *
    * @param files - Map of filename to content (string or Buffer)
@@ -72,9 +85,9 @@ export class IsolatedContainerVolume {
       });
     }
 
-    // Create unique volume name with timestamp to prevent collisions
-    const timestamp = Date.now();
-    this.volumeName = `tenant-${this.tenantId}-run-${this.runId}-${timestamp}`;
+    // Create deterministic volume name from tenantId + runId
+    // runId is unique per workflow execution, so no timestamp needed
+    this.volumeName = IsolatedContainerVolume.deriveVolumeName(this.tenantId, this.runId);
 
     try {
       // Create the volume with labels for tracking


### PR DESCRIPTION
## Summary
- Replace timestamp-based volume naming with deterministic names derived from `tenantId` and `runId`
- Add static `deriveVolumeName()` method to `IsolatedContainerVolume` so downstream components (scanners) can reference volumes created by upstream components (clone-repo) in the same workflow execution without passing volume names through the graph
- Since `runId` is unique per workflow execution, timestamps are no longer needed to prevent collisions

## Test plan
- [x] Run a workflow that clones a repo and runs a scanner — verify the scanner mounts the same volume created by clone-repo
- [x] Verify `IsolatedContainerVolume.deriveVolumeName(tenantId, runId)` returns consistent names