### PR TITLE
fix(worker): restore unique per-node volume names

### DIFF
--- a/worker/src/utils/isolated-volume.ts
+++ b/worker/src/utils/isolated-volume.ts
@@ -51,19 +51,6 @@ export class IsolatedContainerVolume {
   }
 
   /**
-   * Derives the deterministic volume name for a given tenant and run.
-   * Downstream components can use this to reference an existing volume
-   * created by an upstream component in the same workflow execution.
-   *
-   * @param tenantId - Tenant identifier
-   * @param runId - Unique run/execution identifier
-   * @returns The volume name (e.g., `tenant-foo-run-bar`)
-   */
-  static deriveVolumeName(tenantId: string, runId: string): string {
-    return `tenant-${tenantId}-run-${runId}`;
-  }
-
-  /**
    * Creates the isolated volume and populates it with files.
    *
    * @param files - Map of filename to content (string or Buffer)
@@ -85,9 +72,10 @@ export class IsolatedContainerVolume {
       });
     }
 
-    // Create deterministic volume name from tenantId + runId
-    // runId is unique per workflow execution, so no timestamp needed
-    this.volumeName = IsolatedContainerVolume.deriveVolumeName(this.tenantId, this.runId);
+    // Create unique volume name with timestamp to prevent collisions
+    // when parallel nodes in the same run each create their own volume.
+    const timestamp = Date.now();
+    this.volumeName = `tenant-${this.tenantId}-run-${this.runId}-${timestamp}`;
 
     try {
       // Create the volume with labels for tracking


### PR DESCRIPTION
## Summary
- **Fixes regression from #270** — deterministic naming (`tenant-{id}-run-{runId}`) removed timestamps, making every node in the same workflow run share one Docker volume name
- Parallel branches can overwrite each other's files and one branch's cleanup can remove the shared volume while another branch is still using it
- **Reverts to timestamp-based naming** in `initialize()` so each node gets a unique volume
- **Removes `deriveVolumeName()`** — scanners should receive the volume name from clone-repo's output via the workflow graph, not derive it

## Test plan
- [ ] Run a workflow with parallel nodes that each create their own volume — verify unique names
- [ ] Run a clone-repo → scanner workflow — verify scanners receive `volumeName` from clone-repo output via graph edges