### PR TITLE
fix(pm2): use instance-aware env for frontend VITE_API_URL

### DIFF
--- a/pm2.config.cjs
+++ b/pm2.config.cjs
@@ -178,7 +178,11 @@ function loadFrontendEnv(envFilePath) {
         const match = trimmed.match(/^([^=]+)=(.*)$/);
         if (match) {
           const key = match[1].trim();
-          const value = match[2].trim();
+          let value = match[2].trim();
+          // Remove surrounding quotes if present
+          if ((value.startsWith('"') && value.endsWith('"')) || (value.startsWith("'") && value.endsWith("'"))) {
+            value = value.slice(1, -1);
+          }
           // Only include VITE_* variables for frontend
           if (key.startsWith('VITE_')) {
             env[key] = value;


### PR DESCRIPTION
## Summary
- Remove hardcoded `VITE_API_URL` that bypassed nginx routing (`http://localhost:<port>` → direct to backend)
- Make `loadFrontendEnv()` instance-aware by accepting an env file path, so it reads from the correct instance-specific env file via `resolveEnvFile()`
- Default instance (0) now uses `frontend/.env` where `VITE_API_URL=http://localhost` routes through nginx

## Context
The hardcoded `VITE_API_URL` was added in #265 for multi-instance support, but it bypassed nginx which handles `/api/*` routing. The fix preserves multi-instance support — instance N reads from `.instances/instance-N/frontend.env` if it exists.

## Test plan
- [x] Start instance 0 (`just dev 0 start`) — verify API calls go through nginx (`http://localhost/api/...`)
- [x] Start instance 1 with a custom `.instances/instance-1/frontend.env` containing `VITE_API_URL=http://localhost:3311` — verify it uses the instance-specific URL
- [x] Verify frontend loads and can authenticate/make API calls normally