### PR TITLE
feat: disable View Analytics button when no analytics sink connected

### DIFF
--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -29,6 +29,7 @@ import { useWorkflowUiStore } from '@/store/workflowUiStore';
 import { useAuthStore, DEFAULT_ORG_ID } from '@/store/authStore';
 import { cn } from '@/lib/utils';
 import { env } from '@/config/env';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface TopBarProps {
   workflowId?: string;
@@ -45,6 +46,7 @@ interface TopBarProps {
   onRedo?: () => void;
   canUndo?: boolean;
   canRedo?: boolean;
+  hasAnalyticsSink?: boolean;
 }
 
 const DEFAULT_WORKFLOW_NAME = 'Untitled Workflow';
@@ -63,6 +65,7 @@ export function TopBar({
   onRedo,
   canUndo,
   canRedo,
+  hasAnalyticsSink = false,
 }: TopBarProps) {
   const navigate = useNavigate();
   const [isSaving, setIsSaving] = useState(false);
@@ -469,48 +472,63 @@ export function TopBar({
               {env.VITE_OPENSEARCH_DASHBOARDS_URL &&
                 workflowId &&
                 (!selectedRunId || (selectedRunStatus && selectedRunStatus !== 'RUNNING')) && (
-                  <Button
-                    variant="outline"
-                    size="sm"
-                    className="gap-1.5 md:gap-2 min-w-0"
-                    disabled={!isOrgReady}
-                    onClick={() => {
-                      if (!isOrgReady) return;
-                      const baseUrl = env.VITE_OPENSEARCH_DASHBOARDS_URL.replace(/\/+$/, '');
-                      // Filter by run_id if a specific run is selected, otherwise by workflow_id
-                      const filterQuery = selectedRunId
-                        ? `shipsec.run_id.keyword:"${selectedRunId}"`
-                        : `shipsec.workflow_id.keyword:"${workflowId}"`;
-                      // Use the run's backend-resolved org ID when available (matches indexed data),
-                      // fall back to auth store org ID for workflow-level queries
-                      const effectiveOrgId = (selectedRunOrgId || organizationId).toLowerCase();
-                      const orgScopedPattern = `security-findings-${effectiveOrgId}-*`;
-                      // OpenSearch Data Explorer URL format
-                      // Use .keyword fields for exact match filtering
-                      // Use 'all time' range (1 year) since run_id is unique - no need to filter by time
-                      const aParam = encodeURIComponent(
-                        `(discover:(columns:!(_source),interval:auto,sort:!()),metadata:(indexPattern:'${orgScopedPattern}',view:discover))`,
-                      );
-                      const qParam = encodeURIComponent(
-                        `(query:(language:kuery,query:'${filterQuery}'))`,
-                      );
-                      const gParam = encodeURIComponent(
-                        '(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1y,to:now))',
-                      );
-                      const url = `${baseUrl}/app/data-explorer/discover/#?_a=${aParam}&_q=${qParam}&_g=${gParam}`;
-                      window.open(url, '_blank', 'noopener,noreferrer');
-                    }}
-                    title={
-                      !isOrgReady
-                        ? 'Loading organization context...'
-                        : selectedRunId
-                          ? 'View analytics for this run in OpenSearch Dashboards'
-                          : 'View analytics for this workflow in OpenSearch Dashboards'
-                    }
-                  >
-                    <ExternalLink className="h-4 w-4" />
-                    <span className="hidden lg:inline">View Analytics</span>
-                  </Button>
+                  <TooltipProvider>
+                    <Tooltip>
+                      <TooltipTrigger asChild>
+                        <span className="inline-flex">
+                          <Button
+                            variant="outline"
+                            size="sm"
+                            className="gap-1.5 md:gap-2 min-w-0"
+                            disabled={!isOrgReady || !hasAnalyticsSink}
+                            onClick={() => {
+                              if (!isOrgReady || !hasAnalyticsSink) return;
+                              const baseUrl = env.VITE_OPENSEARCH_DASHBOARDS_URL.replace(
+                                /\/+$/,
+                                '',
+                              );
+                              // Filter by run_id if a specific run is selected, otherwise by workflow_id
+                              const filterQuery = selectedRunId
+                                ? `shipsec.run_id.keyword:"${selectedRunId}"`
+                                : `shipsec.workflow_id.keyword:"${workflowId}"`;
+                              // Use the run's backend-resolved org ID when available (matches indexed data),
+                              // fall back to auth store org ID for workflow-level queries
+                              const effectiveOrgId = (
+                                selectedRunOrgId || organizationId
+                              ).toLowerCase();
+                              const orgScopedPattern = `security-findings-${effectiveOrgId}-*`;
+                              // OpenSearch Data Explorer URL format
+                              // Use .keyword fields for exact match filtering
+                              // Use 'all time' range (1 year) since run_id is unique - no need to filter by time
+                              const aParam = encodeURIComponent(
+                                `(discover:(columns:!(_source),interval:auto,sort:!()),metadata:(indexPattern:'${orgScopedPattern}',view:discover))`,
+                              );
+                              const qParam = encodeURIComponent(
+                                `(query:(language:kuery,query:'${filterQuery}'))`,
+                              );
+                              const gParam = encodeURIComponent(
+                                '(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1y,to:now))',
+                              );
+                              const url = `${baseUrl}/app/data-explorer/discover/#?_a=${aParam}&_q=${qParam}&_g=${gParam}`;
+                              window.open(url, '_blank', 'noopener,noreferrer');
+                            }}
+                          >
+                            <ExternalLink className="h-4 w-4" />
+                            <span className="hidden lg:inline">View Analytics</span>
+                          </Button>
+                        </span>
+                      </TooltipTrigger>
+                      <TooltipContent>
+                        {!hasAnalyticsSink
+                          ? 'Connect analytics sink to view analytics'
+                          : !isOrgReady
+                            ? 'Loading organization context...'
+                            : selectedRunId
+                              ? 'View analytics for this run in OpenSearch Dashboards'
+                              : 'View analytics for this workflow in OpenSearch Dashboards'}
+                      </TooltipContent>
+                    </Tooltip>
+                  </TooltipProvider>
                 )}
 
               <Button

--- a/frontend/src/features/workflow-builder/WorkflowBuilder.tsx
+++ b/frontend/src/features/workflow-builder/WorkflowBuilder.tsx
@@ -916,6 +916,15 @@ function WorkflowBuilderContent() {
   // This allows smooth transition without forcing mode change
   const isInspectorVisible = mode === 'execution' || (selectedRunId !== null && mode !== 'design');
 
+  const hasAnalyticsSink = useMemo(() => {
+    // When viewing a specific run, bypass the sink check — the run may have
+    // indexed results even if the current design no longer contains a sink.
+    if (selectedRunId) return true;
+    return designNodes.some((node) => {
+      return (node.data?.componentId ?? node.data?.componentSlug) === 'core.analytics.sink';
+    });
+  }, [designNodes, selectedRunId]);
+
   const shouldShowInitialLoader =
     isLoading && designNodes.length === 0 && executionNodes.length === 0 && !isNewWorkflow;
 
@@ -948,6 +957,7 @@ function WorkflowBuilderContent() {
       onRedo={redo}
       canUndo={canUndo}
       canRedo={canRedo}
+      hasAnalyticsSink={hasAnalyticsSink}
     />
   );
 


### PR DESCRIPTION
## Summary
- Disable the **View Analytics** button in the top bar when the workflow doesn't have an analytics sink node (`core.analytics.sink` / `analytics-sink`)
- Add a tooltip explaining why the button is disabled ("Connect analytics sink to view analytics")
- Pass `hasAnalyticsSink` prop from `WorkflowBuilder` to `TopBar` using a `useMemo` check on design nodes

## Screenshots
**Without sink :**
<img width="940" height="686" alt="image" src="https://github.com/user-attachments/assets/6dd90f54-e0d9-40aa-986e-da8bff4359d4" />
<img width="1298" height="801" alt="image" src="https://github.com/user-attachments/assets/8a2647e8-d50c-4cf2-aa62-3c97bdf2698c" />

**When added `analytics sink` :**

<img width="946" height="639" alt="image" src="https://github.com/user-attachments/assets/b0fcc092-4592-4285-91de-bd4a23967282" />


## Test plan
- [x] Open a workflow **without** an analytics sink node — verify the View Analytics button is disabled with an explanatory tooltip
- [x] Open a workflow **with** an analytics sink node — verify the button is enabled and opens OpenSearch Dashboards
- [x] Add/remove an analytics sink node and verify the button state updates reactively