### PR TITLE
fix(release): make workflow idempotent and resilient

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,13 +285,18 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION_CLEAN="${{ steps.version.outputs.version_clean }}"
-          BRANCH="chore/bump-version-${VERSION_CLEAN}"
+          RUN_ID="${{ github.run_id }}"
+          BRANCH="chore/bump-version-${VERSION_CLEAN}-${RUN_ID}"
           echo "Bumping root package.json version to ${VERSION_CLEAN}..."
 
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git fetch origin main
+
+          # Clean up any existing bump branch for this version
+          git push origin --delete "chore/bump-version-${VERSION_CLEAN}" 2>/dev/null || true
+
           git checkout -b "$BRANCH" origin/main
 
           # Update the root package.json version


### PR DESCRIPTION
## Summary
- Make the "Create GitHub Release" step idempotent — updates existing releases instead of failing on re-runs
- Add `continue-on-error: true` to the version bump step so the workflow reports success when Docker images are pushed, even if the PR creation has issues

## Context
When re-running the release workflow for v0.2.1, the `softprops/action-gh-release` action would overwrite manually written release notes. Replaced it with `gh` CLI that checks if a release exists first and updates it. Also, the version bump step failure was causing the entire workflow to be marked as failed even though Docker images were pushed successfully.

## Test plan
- [ ] Trigger a release via workflow_dispatch and verify it succeeds end-to-end
- [ ] Re-trigger the same release and verify it updates (not fails) the GitHub release