### PR TITLE
chore: update downloader domain

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ The easiest way to run ShipSec Studio on your own infrastructure:
 #### One-Line Install
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ShipSecAI/studio/main/install.sh | bash
+curl -fsSL https://get.shipsec.ai | bash
 ```
 
 This installer will:


### PR DESCRIPTION
## Summary
- Update the CLI installer URL from the old domain to `get.shipsec.ai`

## Test plan
- [x] Verified the new URL resolves correctly