### PR TITLE
feat: Add first-time user onboarding with spotlight tours for app and workflow builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Set up Bun
         uses: oven-sh/setup-bun@v1
         with:
-          bun-version: latest
+          bun-version: 1.3.9
 
       - name: Install dependencies
         run: bun install

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -35,6 +35,7 @@ import { HumanInputsModule } from './human-inputs/human-inputs.module';
 import { McpServersModule } from './mcp-servers/mcp-servers.module';
 import { McpGroupsModule } from './mcp-groups/mcp-groups.module';
 import { TemplatesModule } from './templates/templates.module';
+import { UserPreferencesModule } from './user-preferences/user-preferences.module';
 
 const coreModules = [
   AgentsModule,
@@ -56,6 +57,7 @@ const coreModules = [
   StudioMcpModule,
   TemplatesModule,
   AuditModule,
+  UserPreferencesModule,
 ];
 
 const testingModules = process.env.NODE_ENV === 'production' ? [] : [TestingSupportModule];

--- a/backend/src/database/schema/index.ts
+++ b/backend/src/database/schema/index.ts
@@ -22,3 +22,4 @@ export * from './mcp-servers';
 export * from './node-io';
 export * from './organization-settings';
 export * from './templates';
+export * from './user-preferences';

--- a/backend/src/database/schema/user-preferences.ts
+++ b/backend/src/database/schema/user-preferences.ts
@@ -1,0 +1,20 @@
+import { boolean, index, pgTable, primaryKey, timestamp, varchar } from 'drizzle-orm/pg-core';
+
+export const userPreferencesTable = pgTable(
+  'user_preferences',
+  {
+    userId: varchar('user_id', { length: 191 }).notNull(),
+    organizationId: varchar('organization_id', { length: 191 }).notNull(),
+    hasCompletedOnboarding: boolean('has_completed_onboarding').notNull().default(false),
+    hasCompletedBuilderTour: boolean('has_completed_builder_tour').notNull().default(false),
+    createdAt: timestamp('created_at', { withTimezone: true }).defaultNow().notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).defaultNow().notNull(),
+  },
+  (table) => ({
+    pk: primaryKey({ columns: [table.userId, table.organizationId] }),
+    orgIdx: index('user_preferences_org_idx').on(table.organizationId),
+  }),
+);
+
+export type UserPreferences = typeof userPreferencesTable.$inferSelect;
+export type NewUserPreferences = typeof userPreferencesTable.$inferInsert;

--- a/backend/src/user-preferences/user-preferences.controller.ts
+++ b/backend/src/user-preferences/user-preferences.controller.ts
@@ -1,0 +1,30 @@
+import { Body, Controller, Get, Patch } from '@nestjs/common';
+import { ApiOkResponse, ApiTags } from '@nestjs/swagger';
+
+import { UserPreferencesService } from './user-preferences.service';
+import { UpdateUserPreferencesDto, UserPreferencesResponseDto } from './user-preferences.dto';
+import { CurrentAuth } from '../auth/auth-context.decorator';
+import type { AuthContext } from '../auth/types';
+
+@ApiTags('user-preferences')
+@Controller('users/me/preferences')
+export class UserPreferencesController {
+  constructor(private readonly service: UserPreferencesService) {}
+
+  @Get()
+  @ApiOkResponse({ type: UserPreferencesResponseDto })
+  async getPreferences(
+    @CurrentAuth() auth: AuthContext | null,
+  ): Promise<UserPreferencesResponseDto> {
+    return this.service.getPreferences(auth);
+  }
+
+  @Patch()
+  @ApiOkResponse({ type: UserPreferencesResponseDto })
+  async updatePreferences(
+    @CurrentAuth() auth: AuthContext | null,
+    @Body() body: UpdateUserPreferencesDto,
+  ): Promise<UserPreferencesResponseDto> {
+    return this.service.updatePreferences(auth, body);
+  }
+}

--- a/backend/src/user-preferences/user-preferences.dto.ts
+++ b/backend/src/user-preferences/user-preferences.dto.ts
@@ -1,0 +1,22 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsBoolean, IsOptional } from 'class-validator';
+
+export class UpdateUserPreferencesDto {
+  @ApiPropertyOptional({ description: 'Whether the user has completed the onboarding tour' })
+  @IsOptional()
+  @IsBoolean()
+  hasCompletedOnboarding?: boolean;
+
+  @ApiPropertyOptional({ description: 'Whether the user has completed the workflow builder tour' })
+  @IsOptional()
+  @IsBoolean()
+  hasCompletedBuilderTour?: boolean;
+}
+
+export class UserPreferencesResponseDto {
+  @ApiProperty()
+  hasCompletedOnboarding!: boolean;
+
+  @ApiProperty()
+  hasCompletedBuilderTour!: boolean;
+}

--- a/backend/src/user-preferences/user-preferences.module.ts
+++ b/backend/src/user-preferences/user-preferences.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+
+import { DatabaseModule } from '../database/database.module';
+import { UserPreferencesController } from './user-preferences.controller';
+import { UserPreferencesRepository } from './user-preferences.repository';
+import { UserPreferencesService } from './user-preferences.service';
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [UserPreferencesController],
+  providers: [UserPreferencesService, UserPreferencesRepository],
+  exports: [UserPreferencesService],
+})
+export class UserPreferencesModule {}

--- a/backend/src/user-preferences/user-preferences.repository.ts
+++ b/backend/src/user-preferences/user-preferences.repository.ts
@@ -1,0 +1,73 @@
+import { Inject, Injectable } from '@nestjs/common';
+import { NodePgDatabase } from 'drizzle-orm/node-postgres';
+import { and, eq, sql } from 'drizzle-orm';
+
+import { DRIZZLE_TOKEN } from '../database/database.module';
+import { userPreferencesTable } from '../database/schema';
+
+export interface UserPreferencesData {
+  hasCompletedOnboarding: boolean;
+  hasCompletedBuilderTour: boolean;
+}
+
+@Injectable()
+export class UserPreferencesRepository {
+  constructor(
+    @Inject(DRIZZLE_TOKEN)
+    private readonly db: NodePgDatabase,
+  ) {}
+
+  async findByUserAndOrg(
+    userId: string,
+    organizationId: string,
+  ): Promise<UserPreferencesData | null> {
+    const rows = await this.db
+      .select({
+        hasCompletedOnboarding: userPreferencesTable.hasCompletedOnboarding,
+        hasCompletedBuilderTour: userPreferencesTable.hasCompletedBuilderTour,
+      })
+      .from(userPreferencesTable)
+      .where(
+        and(
+          eq(userPreferencesTable.userId, userId),
+          eq(userPreferencesTable.organizationId, organizationId),
+        ),
+      )
+      .limit(1);
+
+    return rows[0] ?? null;
+  }
+
+  async upsert(
+    userId: string,
+    organizationId: string,
+    updates: Partial<UserPreferencesData>,
+  ): Promise<UserPreferencesData> {
+    const [result] = await this.db
+      .insert(userPreferencesTable)
+      .values({
+        userId,
+        organizationId,
+        hasCompletedOnboarding: updates.hasCompletedOnboarding ?? false,
+        hasCompletedBuilderTour: updates.hasCompletedBuilderTour ?? false,
+      })
+      .onConflictDoUpdate({
+        target: [userPreferencesTable.userId, userPreferencesTable.organizationId],
+        set: {
+          ...(updates.hasCompletedOnboarding !== undefined
+            ? { hasCompletedOnboarding: updates.hasCompletedOnboarding }
+            : {}),
+          ...(updates.hasCompletedBuilderTour !== undefined
+            ? { hasCompletedBuilderTour: updates.hasCompletedBuilderTour }
+            : {}),
+          updatedAt: sql`now()`,
+        },
+      })
+      .returning({
+        hasCompletedOnboarding: userPreferencesTable.hasCompletedOnboarding,
+        hasCompletedBuilderTour: userPreferencesTable.hasCompletedBuilderTour,
+      });
+
+    return result;
+  }
+}

--- a/backend/src/user-preferences/user-preferences.service.ts
+++ b/backend/src/user-preferences/user-preferences.service.ts
@@ -1,0 +1,33 @@
+import { Injectable, BadRequestException } from '@nestjs/common';
+
+import { UserPreferencesRepository, type UserPreferencesData } from './user-preferences.repository';
+import type { AuthContext } from '../auth/types';
+import { DEFAULT_ORGANIZATION_ID } from '../auth/constants';
+
+@Injectable()
+export class UserPreferencesService {
+  constructor(private readonly repository: UserPreferencesRepository) {}
+
+  private resolveIds(auth: AuthContext | null): { userId: string; organizationId: string } {
+    const userId = auth?.userId;
+    if (!userId) {
+      throw new BadRequestException('User context is required');
+    }
+    const organizationId = auth?.organizationId ?? DEFAULT_ORGANIZATION_ID;
+    return { userId, organizationId };
+  }
+
+  async getPreferences(auth: AuthContext | null): Promise<UserPreferencesData> {
+    const { userId, organizationId } = this.resolveIds(auth);
+    const prefs = await this.repository.findByUserAndOrg(userId, organizationId);
+    return prefs ?? { hasCompletedOnboarding: false, hasCompletedBuilderTour: false };
+  }
+
+  async updatePreferences(
+    auth: AuthContext | null,
+    updates: Partial<UserPreferencesData>,
+  ): Promise<UserPreferencesData> {
+    const { userId, organizationId } = this.resolveIds(auth);
+    return this.repository.upsert(userId, organizationId, updates);
+  }
+}

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -95,11 +95,16 @@ export function AppLayout({ children }: AppLayoutProps) {
   const openCommandPalette = useCommandPaletteStore((state) => state.open);
 
   // Onboarding tutorial state (persisted in DB via API)
-  const { data: userPreferences, isLoading: prefsLoading } = useUserPreferences();
+  const {
+    data: userPreferences,
+    isLoading: prefsLoading,
+    isSuccess: prefsLoaded,
+  } = useUserPreferences();
   const updatePreferences = useUpdateUserPreferences();
-  const hasCompletedOnboarding = prefsLoading
-    ? true
-    : (userPreferences?.hasCompletedOnboarding ?? true);
+  // While loading: hide dialog (true). After loaded: use server value, default false for new users.
+  const hasCompletedOnboarding = prefsLoaded
+    ? (userPreferences?.hasCompletedOnboarding ?? false)
+    : true;
   const onboardingStep = useOnboardingStore((state) => state.currentStep);
   const setOnboardingStep = useOnboardingStore((state) => state.setCurrentStep);
   const completeOnboarding = () => updatePreferences.mutate({ hasCompletedOnboarding: true });

--- a/frontend/src/components/layout/AppLayout.tsx
+++ b/frontend/src/components/layout/AppLayout.tsx
@@ -43,6 +43,10 @@ import { usePrefetchOnIdle } from '@/hooks/usePrefetchOnIdle';
 import { prefetchIdleRoutes, prefetchRoute } from '@/lib/prefetch-routes';
 import { OnboardingDialog } from '@/components/onboarding/OnboardingDialog';
 import { useOnboardingStore } from '@/store/onboardingStore';
+import {
+  useUserPreferences,
+  useUpdateUserPreferences,
+} from '@/hooks/queries/useUserPreferencesQueries';
 
 interface AppLayoutProps {
   children: React.ReactNode;
@@ -90,11 +94,52 @@ export function AppLayout({ children }: AppLayoutProps) {
   const { theme, startTransition } = useThemeStore();
   const openCommandPalette = useCommandPaletteStore((state) => state.open);
 
-  // Onboarding tutorial state
-  const hasCompletedOnboarding = useOnboardingStore((state) => state.hasCompletedOnboarding);
+  // Onboarding tutorial state (persisted in DB via API)
+  const { data: userPreferences, isLoading: prefsLoading } = useUserPreferences();
+  const updatePreferences = useUpdateUserPreferences();
+  const hasCompletedOnboarding = prefsLoading
+    ? true
+    : (userPreferences?.hasCompletedOnboarding ?? true);
   const onboardingStep = useOnboardingStore((state) => state.currentStep);
   const setOnboardingStep = useOnboardingStore((state) => state.setCurrentStep);
-  const completeOnboarding = useOnboardingStore((state) => state.completeOnboarding);
+  const completeOnboarding = () => updatePreferences.mutate({ hasCompletedOnboarding: true });
+
+  // One-time migration: localStorage -> DB
+  useEffect(() => {
+    if (prefsLoading || !isAuthenticated) return;
+
+    const STORAGE_KEY = 'shipsec-onboarding';
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return;
+
+    try {
+      const stored = JSON.parse(raw);
+      const localState = stored?.state;
+      if (!localState) {
+        localStorage.removeItem(STORAGE_KEY);
+        return;
+      }
+
+      const updates: { hasCompletedOnboarding?: boolean; hasCompletedBuilderTour?: boolean } = {};
+
+      if (localState.hasCompletedOnboarding && !userPreferences?.hasCompletedOnboarding) {
+        updates.hasCompletedOnboarding = true;
+      }
+      if (localState.hasCompletedBuilderTour && !userPreferences?.hasCompletedBuilderTour) {
+        updates.hasCompletedBuilderTour = true;
+      }
+
+      if (Object.keys(updates).length > 0) {
+        updatePreferences.mutate(updates, {
+          onSuccess: () => localStorage.removeItem(STORAGE_KEY),
+        });
+      } else {
+        localStorage.removeItem(STORAGE_KEY);
+      }
+    } catch {
+      localStorage.removeItem(STORAGE_KEY);
+    }
+  }, [prefsLoading, isAuthenticated]);
 
   // Get git SHA for version display (monorepo - same for frontend and backend)
   const gitSha = env.VITE_GIT_SHA;
@@ -412,7 +457,7 @@ export function AppLayout({ children }: AppLayoutProps) {
     <SidebarContext.Provider value={sidebarContextValue}>
       <ThemeTransition />
       <OnboardingDialog
-        open={isAuthenticated && !hasCompletedOnboarding}
+        open={isAuthenticated && !prefsLoading && !hasCompletedOnboarding}
         onComplete={completeOnboarding}
         currentStep={onboardingStep}
         onStepChange={setOnboardingStep}

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -430,8 +430,26 @@ export function TopBar({
                         <span>Redo</span>
                         <span className="ml-auto pl-4 text-xs text-muted-foreground">⌘⇧Z</span>
                       </DropdownMenuItem>
-                      <DropdownMenuSeparator />
                     </>
+                  )}
+                  {mode === 'design' && (onImport || onExport) && <DropdownMenuSeparator />}
+                  {mode === 'design' && onImport && (
+                    <DropdownMenuItem
+                      onClick={handleImportClick}
+                      disabled={!canEdit || isImporting}
+                    >
+                      <Upload className="mr-2 h-4 w-4" />
+                      <span>Import</span>
+                    </DropdownMenuItem>
+                  )}
+                  {mode === 'design' && onExport && (
+                    <DropdownMenuItem onClick={handleExport} disabled={!canEdit}>
+                      <Download className="mr-2 h-4 w-4" />
+                      <span>Export</span>
+                    </DropdownMenuItem>
+                  )}
+                  {(onPublishTemplate || env.VITE_OPENSEARCH_DASHBOARDS_URL) && (
+                    <DropdownMenuSeparator />
                   )}
                   {onPublishTemplate && isInWorkflowBuilder && (
                     <DropdownMenuItem onClick={onPublishTemplate} disabled={!canEdit}>
@@ -469,22 +487,6 @@ export function TopBar({
                         <span>View Analytics</span>
                       </DropdownMenuItem>
                     )}
-                  {mode === 'design' && (onImport || onExport) && <DropdownMenuSeparator />}
-                  {mode === 'design' && onImport && (
-                    <DropdownMenuItem
-                      onClick={handleImportClick}
-                      disabled={!canEdit || isImporting}
-                    >
-                      <Upload className="mr-2 h-4 w-4" />
-                      <span>Import</span>
-                    </DropdownMenuItem>
-                  )}
-                  {mode === 'design' && onExport && (
-                    <DropdownMenuItem onClick={handleExport} disabled={!canEdit}>
-                      <Download className="mr-2 h-4 w-4" />
-                      <span>Export</span>
-                    </DropdownMenuItem>
-                  )}
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -194,7 +194,10 @@ export function TopBar({
   }, [metadata.name]);
 
   const modeToggle = (
-    <div className="flex rounded-lg border bg-muted/40 overflow-hidden text-xs font-medium shadow-sm flex-shrink-0">
+    <div
+      data-onboarding-builder="mode-toggle"
+      className="flex rounded-lg border bg-muted/40 overflow-hidden text-xs font-medium shadow-sm flex-shrink-0"
+    >
       <Button
         variant={mode === 'design' ? 'default' : 'ghost'}
         size="sm"
@@ -354,6 +357,7 @@ export function TopBar({
               {mode === 'design' && (
                 <>
                   <Button
+                    data-onboarding-builder="save-button"
                     onClick={handleSave}
                     disabled={!canEdit || isSaving || saveState === 'clean'}
                     variant="outline"
@@ -445,7 +449,7 @@ export function TopBar({
                 )}
 
               {/* Run button with dropdown for Publish */}
-              <div className="flex items-center">
+              <div data-onboarding-builder="run-button" className="flex items-center">
                 <Button
                   onClick={handleRun}
                   disabled={!canEdit}
@@ -491,7 +495,12 @@ export function TopBar({
                   )}
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
-                      <Button variant="ghost" size="icon" className="h-8 w-8">
+                      <Button
+                        data-onboarding-builder="more-options"
+                        variant="ghost"
+                        size="icon"
+                        className="h-8 w-8"
+                      >
                         <MoreVertical className="h-4 w-4" />
                       </Button>
                     </DropdownMenuTrigger>

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -463,6 +463,7 @@ export function TopBar({
                   <DropdownMenu>
                     <DropdownMenuTrigger asChild>
                       <Button
+                        data-onboarding-builder="publish-trigger"
                         size="sm"
                         className="px-1.5 rounded-l-none border-l border-primary-foreground/20"
                         disabled={!canEdit}

--- a/frontend/src/components/layout/TopBar.tsx
+++ b/frontend/src/components/layout/TopBar.tsx
@@ -18,7 +18,6 @@ import {
   Redo2,
   ExternalLink,
   Package,
-  ChevronDown,
 } from 'lucide-react';
 import {
   DropdownMenu,
@@ -32,7 +31,6 @@ import { useWorkflowUiStore } from '@/store/workflowUiStore';
 import { useAuthStore, DEFAULT_ORG_ID } from '@/store/authStore';
 import { cn } from '@/lib/utils';
 import { env } from '@/config/env';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
 
 interface TopBarProps {
   workflowId?: string;
@@ -386,126 +384,42 @@ export function TopBar({
                 </>
               )}
 
-              {env.VITE_OPENSEARCH_DASHBOARDS_URL &&
-                workflowId &&
-                (!selectedRunId || (selectedRunStatus && selectedRunStatus !== 'RUNNING')) && (
-                  <TooltipProvider>
-                    <Tooltip>
-                      <TooltipTrigger asChild>
-                        <span className="inline-flex">
-                          <Button
-                            variant="outline"
-                            size="sm"
-                            className="gap-1.5 md:gap-2 min-w-0"
-                            disabled={!isOrgReady || !hasAnalyticsSink}
-                            onClick={() => {
-                              if (!isOrgReady || !hasAnalyticsSink) return;
-                              const baseUrl = env.VITE_OPENSEARCH_DASHBOARDS_URL.replace(
-                                /\/+$/,
-                                '',
-                              );
-                              // Filter by run_id if a specific run is selected, otherwise by workflow_id
-                              const filterQuery = selectedRunId
-                                ? `shipsec.run_id.keyword:"${selectedRunId}"`
-                                : `shipsec.workflow_id.keyword:"${workflowId}"`;
-                              // Use the run's backend-resolved org ID when available (matches indexed data),
-                              // fall back to auth store org ID for workflow-level queries
-                              const effectiveOrgId = (
-                                selectedRunOrgId || organizationId
-                              ).toLowerCase();
-                              const orgScopedPattern = `security-findings-${effectiveOrgId}-*`;
-                              // OpenSearch Data Explorer URL format
-                              // Use .keyword fields for exact match filtering
-                              // Use 'all time' range (1 year) since run_id is unique - no need to filter by time
-                              const aParam = encodeURIComponent(
-                                `(discover:(columns:!(_source),interval:auto,sort:!()),metadata:(indexPattern:'${orgScopedPattern}',view:discover))`,
-                              );
-                              const qParam = encodeURIComponent(
-                                `(query:(language:kuery,query:'${filterQuery}'))`,
-                              );
-                              const gParam = encodeURIComponent(
-                                '(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1y,to:now))',
-                              );
-                              const url = `${baseUrl}/app/data-explorer/discover/#?_a=${aParam}&_q=${qParam}&_g=${gParam}`;
-                              window.open(url, '_blank', 'noopener,noreferrer');
-                            }}
-                          >
-                            <ExternalLink className="h-4 w-4" />
-                            <span className="hidden lg:inline">View Analytics</span>
-                          </Button>
-                        </span>
-                      </TooltipTrigger>
-                      <TooltipContent>
-                        {!hasAnalyticsSink
-                          ? 'Connect analytics sink to view analytics'
-                          : !isOrgReady
-                            ? 'Loading organization context...'
-                            : selectedRunId
-                              ? 'View analytics for this run in OpenSearch Dashboards'
-                              : 'View analytics for this workflow in OpenSearch Dashboards'}
-                      </TooltipContent>
-                    </Tooltip>
-                  </TooltipProvider>
-                )}
+              {/* Run button */}
+              <Button
+                data-onboarding-builder="run-button"
+                onClick={handleRun}
+                disabled={!canEdit}
+                size="sm"
+                className="gap-1.5 md:gap-2 min-w-0"
+              >
+                <Play className="h-4 w-4" />
+                <span className="hidden sm:inline">Run</span>
+              </Button>
 
-              {/* Run button with dropdown for Publish */}
-              <div data-onboarding-builder="run-button" className="flex items-center">
-                <Button
-                  onClick={handleRun}
-                  disabled={!canEdit}
-                  size="sm"
-                  className="gap-1.5 md:gap-2 min-w-0 rounded-r-none"
-                >
-                  <Play className="h-4 w-4" />
-                  <span className="hidden sm:inline">Run</span>
-                </Button>
-                {onPublishTemplate && isInWorkflowBuilder && (
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        data-onboarding-builder="publish-trigger"
-                        size="sm"
-                        className="px-1.5 rounded-l-none border-l border-primary-foreground/20"
-                        disabled={!canEdit}
-                        aria-label="More actions"
-                      >
-                        <ChevronDown className="h-4 w-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end" className="min-w-[180px]">
-                      <DropdownMenuItem onClick={onPublishTemplate} disabled={!canEdit}>
-                        <Package className="mr-2 h-4 w-4" />
-                        <span>Publish as Template</span>
-                      </DropdownMenuItem>
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                )}
-              </div>
-
-              {/* Vertical three-dots menu: Undo, Redo, Import, Export */}
-              {mode === 'design' && (
-                <>
-                  {onImport && (
-                    <input
-                      ref={fileInputRef}
-                      type="file"
-                      accept="application/json"
-                      className="hidden"
-                      onChange={handleFileChange}
-                    />
-                  )}
-                  <DropdownMenu>
-                    <DropdownMenuTrigger asChild>
-                      <Button
-                        data-onboarding-builder="more-options"
-                        variant="ghost"
-                        size="icon"
-                        className="h-8 w-8"
-                      >
-                        <MoreVertical className="h-4 w-4" />
-                      </Button>
-                    </DropdownMenuTrigger>
-                    <DropdownMenuContent align="end">
+              {/* More options menu: Undo, Redo, Import, Export, Publish, Analytics */}
+              {onImport && (
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="application/json"
+                  className="hidden"
+                  onChange={handleFileChange}
+                />
+              )}
+              <DropdownMenu>
+                <DropdownMenuTrigger asChild>
+                  <Button
+                    data-onboarding-builder="more-options"
+                    variant="ghost"
+                    size="icon"
+                    className="h-8 w-8"
+                  >
+                    <MoreVertical className="h-4 w-4" />
+                  </Button>
+                </DropdownMenuTrigger>
+                <DropdownMenuContent align="end">
+                  {mode === 'design' && (
+                    <>
                       <DropdownMenuItem onClick={onUndo} disabled={!canEdit || !canUndo}>
                         <Undo2 className="mr-2 h-4 w-4" />
                         <span>Undo</span>
@@ -516,26 +430,63 @@ export function TopBar({
                         <span>Redo</span>
                         <span className="ml-auto pl-4 text-xs text-muted-foreground">⌘⇧Z</span>
                       </DropdownMenuItem>
-                      {(onImport || onExport) && <DropdownMenuSeparator />}
-                      {onImport && (
-                        <DropdownMenuItem
-                          onClick={handleImportClick}
-                          disabled={!canEdit || isImporting}
-                        >
-                          <Upload className="mr-2 h-4 w-4" />
-                          <span>Import</span>
-                        </DropdownMenuItem>
-                      )}
-                      {onExport && (
-                        <DropdownMenuItem onClick={handleExport} disabled={!canEdit}>
-                          <Download className="mr-2 h-4 w-4" />
-                          <span>Export</span>
-                        </DropdownMenuItem>
-                      )}
-                    </DropdownMenuContent>
-                  </DropdownMenu>
-                </>
-              )}
+                      <DropdownMenuSeparator />
+                    </>
+                  )}
+                  {onPublishTemplate && isInWorkflowBuilder && (
+                    <DropdownMenuItem onClick={onPublishTemplate} disabled={!canEdit}>
+                      <Package className="mr-2 h-4 w-4" />
+                      <span>Publish as Template</span>
+                    </DropdownMenuItem>
+                  )}
+                  {env.VITE_OPENSEARCH_DASHBOARDS_URL &&
+                    workflowId &&
+                    (!selectedRunId || (selectedRunStatus && selectedRunStatus !== 'RUNNING')) && (
+                      <DropdownMenuItem
+                        disabled={!isOrgReady || !hasAnalyticsSink}
+                        onClick={() => {
+                          if (!isOrgReady || !hasAnalyticsSink) return;
+                          const baseUrl = env.VITE_OPENSEARCH_DASHBOARDS_URL.replace(/\/+$/, '');
+                          const filterQuery = selectedRunId
+                            ? `shipsec.run_id.keyword:"${selectedRunId}"`
+                            : `shipsec.workflow_id.keyword:"${workflowId}"`;
+                          const effectiveOrgId = (selectedRunOrgId || organizationId).toLowerCase();
+                          const orgScopedPattern = `security-findings-${effectiveOrgId}-*`;
+                          const aParam = encodeURIComponent(
+                            `(discover:(columns:!(_source),interval:auto,sort:!()),metadata:(indexPattern:'${orgScopedPattern}',view:discover))`,
+                          );
+                          const qParam = encodeURIComponent(
+                            `(query:(language:kuery,query:'${filterQuery}'))`,
+                          );
+                          const gParam = encodeURIComponent(
+                            '(filters:!(),refreshInterval:(pause:!t,value:0),time:(from:now-1y,to:now))',
+                          );
+                          const url = `${baseUrl}/app/data-explorer/discover/#?_a=${aParam}&_q=${qParam}&_g=${gParam}`;
+                          window.open(url, '_blank', 'noopener,noreferrer');
+                        }}
+                      >
+                        <ExternalLink className="mr-2 h-4 w-4" />
+                        <span>View Analytics</span>
+                      </DropdownMenuItem>
+                    )}
+                  {mode === 'design' && (onImport || onExport) && <DropdownMenuSeparator />}
+                  {mode === 'design' && onImport && (
+                    <DropdownMenuItem
+                      onClick={handleImportClick}
+                      disabled={!canEdit || isImporting}
+                    >
+                      <Upload className="mr-2 h-4 w-4" />
+                      <span>Import</span>
+                    </DropdownMenuItem>
+                  )}
+                  {mode === 'design' && onExport && (
+                    <DropdownMenuItem onClick={handleExport} disabled={!canEdit}>
+                      <Download className="mr-2 h-4 w-4" />
+                      <span>Export</span>
+                    </DropdownMenuItem>
+                  )}
+                </DropdownMenuContent>
+              </DropdownMenu>
             </div>
           </div>
         </div>

--- a/frontend/src/components/onboarding/OnboardingDialog.tsx
+++ b/frontend/src/components/onboarding/OnboardingDialog.tsx
@@ -1,0 +1,343 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { Button } from '@/components/ui/button';
+import {
+  Workflow,
+  Package,
+  CalendarClock,
+  Zap,
+  KeyRound,
+  ArrowRight,
+  ArrowLeft,
+  Sparkles,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface OnboardingStep {
+  title: string;
+  description: string;
+  icon: typeof Sparkles;
+  content: string;
+  color: string;
+  target: string | null;
+}
+
+const ONBOARDING_STEPS: OnboardingStep[] = [
+  {
+    title: 'Welcome to ShipSec Studio!',
+    description: "Let's take a quick tour of the platform.",
+    icon: Sparkles,
+    content:
+      "ShipSec Studio is your all-in-one security automation platform. We'll walk you through the key features to get you started.",
+    color: 'text-purple-500',
+    target: null,
+  },
+  {
+    title: 'Workflow Builder',
+    description: 'Your starting point for security automation.',
+    icon: Workflow,
+    content:
+      'Design powerful security workflows using the visual builder. Drag and drop nodes, configure actions, and chain them together.',
+    color: 'text-blue-500',
+    target: '[data-onboarding="workflow-builder"]',
+  },
+  {
+    title: 'Template Library',
+    description: 'Get started faster with pre-built templates.',
+    icon: Package,
+    content:
+      'Browse ready-made workflow templates for common security tasks. Pick one and customize it to fit your needs.',
+    color: 'text-green-500',
+    target: '[data-onboarding="template-library"]',
+  },
+  {
+    title: 'Schedules',
+    description: 'Automate workflow execution on a schedule.',
+    icon: CalendarClock,
+    content:
+      'Set up schedules to run workflows at specific intervals. Automate recurring security scans and checks effortlessly.',
+    color: 'text-orange-500',
+    target: '[data-onboarding="schedules"]',
+  },
+  {
+    title: 'Action Center',
+    description: 'Monitor and manage workflow results.',
+    icon: Zap,
+    content:
+      'Review workflow executions, inspect findings, and take action on results — all from one central dashboard.',
+    color: 'text-yellow-500',
+    target: '[data-onboarding="action-center"]',
+  },
+  {
+    title: 'Manage Settings',
+    description: 'Secrets, API Keys, and MCP Servers.',
+    icon: KeyRound,
+    content:
+      'Store API keys, tokens, and credentials securely. Configure MCP servers and manage all your sensitive data from here.',
+    color: 'text-red-500',
+    target: '[data-onboarding="manage-section"]',
+  },
+];
+
+const SPOTLIGHT_PADDING = 8;
+const TOOLTIP_GAP = 16;
+const TOOLTIP_WIDTH = 360;
+
+interface OnboardingDialogProps {
+  open: boolean;
+  onComplete: () => void;
+  currentStep: number;
+  onStepChange: (step: number) => void;
+}
+
+export function OnboardingDialog({
+  open,
+  onComplete,
+  currentStep,
+  onStepChange,
+}: OnboardingDialogProps) {
+  const [targetRect, setTargetRect] = useState<DOMRect | null>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+
+  const step = ONBOARDING_STEPS[currentStep];
+  const isLastStep = currentStep === ONBOARDING_STEPS.length - 1;
+  const Icon = step?.icon ?? Sparkles;
+  const isCenter = !step?.target;
+
+  // Track target element position
+  useEffect(() => {
+    if (!open) {
+      setTargetRect(null);
+      return;
+    }
+
+    if (!step?.target) {
+      setTargetRect(null);
+      return;
+    }
+
+    // Delay to allow sidebar animations to settle
+    const timer = setTimeout(() => {
+      const el = document.querySelector(step.target!);
+      if (el) {
+        setTargetRect(el.getBoundingClientRect());
+      } else {
+        setTargetRect(null);
+      }
+    }, 350);
+
+    return () => clearTimeout(timer);
+  }, [open, step?.target, currentStep]);
+
+  // Update on window resize
+  useEffect(() => {
+    if (!open || !step?.target) return;
+
+    const updateRect = () => {
+      const el = document.querySelector(step.target!);
+      if (el) {
+        setTargetRect(el.getBoundingClientRect());
+      }
+    };
+
+    window.addEventListener('resize', updateRect);
+    return () => window.removeEventListener('resize', updateRect);
+  }, [open, step?.target]);
+
+  const handleNext = useCallback(() => {
+    if (isLastStep) {
+      onComplete();
+    } else {
+      onStepChange(currentStep + 1);
+    }
+  }, [isLastStep, onComplete, onStepChange, currentStep]);
+
+  const handleBack = useCallback(() => {
+    if (currentStep > 0) {
+      onStepChange(currentStep - 1);
+    }
+  }, [currentStep, onStepChange]);
+
+  // Global keyboard handler
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        handleNext();
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        handleBack();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        onComplete();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, handleNext, handleBack, onComplete]);
+
+  if (!open || !step) return null;
+
+  // Calculate tooltip position
+  const getTooltipStyle = (): React.CSSProperties => {
+    if (isCenter || !targetRect) {
+      return {
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        width: TOOLTIP_WIDTH,
+      };
+    }
+
+    // Position to the right of the highlighted element
+    const tooltipTop = Math.max(
+      16,
+      Math.min(window.innerHeight - 320, targetRect.top + targetRect.height / 2 - 100),
+    );
+
+    const tooltipLeft = targetRect.right + TOOLTIP_GAP;
+
+    // If tooltip would overflow right edge, position below instead
+    if (tooltipLeft + TOOLTIP_WIDTH > window.innerWidth - 16) {
+      return {
+        top: targetRect.bottom + TOOLTIP_GAP,
+        left: Math.max(16, targetRect.left + targetRect.width / 2 - TOOLTIP_WIDTH / 2),
+        width: TOOLTIP_WIDTH,
+      };
+    }
+
+    return {
+      top: tooltipTop,
+      left: tooltipLeft,
+      width: TOOLTIP_WIDTH,
+    };
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[200]"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Onboarding tour"
+    >
+      {/* Click blocker overlay */}
+      <div className="fixed inset-0" aria-hidden="true" />
+
+      {/* Dimming overlay or spotlight */}
+      {isCenter || !targetRect ? (
+        <div className="fixed inset-0 bg-black/60 transition-opacity duration-300" />
+      ) : (
+        <>
+          {/* Spotlight cutout with smooth transition */}
+          <div
+            className="fixed rounded-lg transition-all duration-500 ease-in-out"
+            style={{
+              top: targetRect.top - SPOTLIGHT_PADDING,
+              left: targetRect.left - SPOTLIGHT_PADDING,
+              width: targetRect.width + SPOTLIGHT_PADDING * 2,
+              height: targetRect.height + SPOTLIGHT_PADDING * 2,
+              boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.6), 0 0 20px 4px rgba(59, 130, 246, 0.25)',
+              pointerEvents: 'none',
+            }}
+          />
+          {/* Pulsing ring around spotlight */}
+          <div
+            className="fixed rounded-lg border-2 border-primary/50 transition-all duration-500 ease-in-out animate-pulse"
+            style={{
+              top: targetRect.top - SPOTLIGHT_PADDING - 2,
+              left: targetRect.left - SPOTLIGHT_PADDING - 2,
+              width: targetRect.width + SPOTLIGHT_PADDING * 2 + 4,
+              height: targetRect.height + SPOTLIGHT_PADDING * 2 + 4,
+              pointerEvents: 'none',
+            }}
+          />
+        </>
+      )}
+
+      {/* Tooltip card */}
+      <div
+        ref={tooltipRef}
+        className={cn(
+          'fixed rounded-xl border bg-background shadow-2xl transition-all duration-300',
+          isCenter ? 'p-6' : 'p-5',
+        )}
+        style={getTooltipStyle()}
+      >
+        {/* Progress indicator */}
+        <div className="flex items-center justify-center gap-1.5 mb-4" role="tablist">
+          {ONBOARDING_STEPS.map((s, index) => (
+            <button
+              key={index}
+              role="tab"
+              aria-selected={index === currentStep}
+              aria-label={`Step ${index + 1}: ${s.title}`}
+              onClick={() => onStepChange(index)}
+              className={cn(
+                'h-1.5 rounded-full transition-all duration-300 hover:opacity-80',
+                index <= currentStep ? 'bg-primary' : 'bg-muted',
+                index === currentStep ? 'w-6' : 'w-1.5',
+              )}
+            />
+          ))}
+        </div>
+
+        {/* Step content */}
+        <div key={currentStep} className="animate-in fade-in duration-200">
+          <div className="flex items-center gap-3 mb-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted">
+              <Icon className={cn('h-5 w-5', step.color)} />
+            </div>
+            <div className="min-w-0">
+              <h3 className="font-semibold text-foreground text-sm leading-tight">{step.title}</h3>
+              <p className="text-xs text-muted-foreground">{step.description}</p>
+            </div>
+          </div>
+
+          <p className="text-sm leading-relaxed text-muted-foreground mb-4">{step.content}</p>
+        </div>
+
+        {/* Navigation footer */}
+        <div className="flex items-center justify-between pt-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onComplete}
+            className="text-muted-foreground text-xs h-8"
+          >
+            Skip tour
+          </Button>
+
+          <div className="flex items-center gap-2">
+            {currentStep > 0 && (
+              <Button variant="outline" size="sm" onClick={handleBack} className="h-8 text-xs">
+                <ArrowLeft className="mr-1 h-3 w-3" />
+                Back
+              </Button>
+            )}
+            <Button size="sm" onClick={handleNext} className="h-8 text-xs">
+              {isLastStep ? (
+                'Get Started'
+              ) : (
+                <>
+                  Next
+                  <ArrowRight className="ml-1 h-3 w-3" />
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+
+        {/* Step counter */}
+        <div className="text-center mt-2">
+          <span className="text-[11px] text-muted-foreground/70">
+            {currentStep + 1} of {ONBOARDING_STEPS.length}
+          </span>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/onboarding/OnboardingDialog.tsx
+++ b/frontend/src/components/onboarding/OnboardingDialog.tsx
@@ -294,33 +294,8 @@ export function OnboardingDialog({
 
         {/* Footer */}
         <div className="px-5 py-3 border-t border-border/40 bg-muted/20">
-          {/* Progress dots */}
-          <div className="flex items-center justify-center gap-1.5 mb-3" role="tablist">
-            {ONBOARDING_STEPS.map((s, index) => (
-              <button
-                key={index}
-                role="tab"
-                aria-selected={index === currentStep}
-                aria-label={`Step ${index + 1}: ${s.title}`}
-                onClick={() => onStepChange(index)}
-                className={cn(
-                  'rounded-full transition-all duration-200 hover:opacity-80',
-                  index === currentStep
-                    ? 'w-6 h-2 bg-primary'
-                    : index < currentStep
-                      ? 'w-2 h-2 bg-primary/50'
-                      : 'w-2 h-2 bg-muted-foreground/20',
-                )}
-              />
-            ))}
-          </div>
-
           <div className="flex items-center justify-between">
-            <span className="text-[11px] text-muted-foreground/60 tabular-nums">
-              {currentStep + 1} / {ONBOARDING_STEPS.length}
-            </span>
-
-            <div className="flex items-center gap-2">
+            <div>
               {currentStep > 0 && (
                 <Button
                   variant="ghost"
@@ -332,17 +307,17 @@ export function OnboardingDialog({
                   Back
                 </Button>
               )}
-              <Button size="sm" onClick={handleNext} className="h-8 text-xs gap-1 px-4 shadow-sm">
-                {isLastStep ? (
-                  'Get Started'
-                ) : (
-                  <>
-                    Next
-                    <ArrowRight className="h-3 w-3" />
-                  </>
-                )}
-              </Button>
             </div>
+            <Button size="sm" onClick={handleNext} className="h-8 text-xs gap-1 px-4 shadow-sm">
+              {isLastStep ? (
+                'Get Started'
+              ) : (
+                <>
+                  Next
+                  <ArrowRight className="h-3 w-3" />
+                </>
+              )}
+            </Button>
           </div>
         </div>
       </div>

--- a/frontend/src/components/onboarding/OnboardingDialog.tsx
+++ b/frontend/src/components/onboarding/OnboardingDialog.tsx
@@ -295,7 +295,7 @@ export function OnboardingDialog({
         {/* Footer */}
         <div className="px-5 py-3 border-t border-border/40 bg-muted/20">
           <div className="flex items-center justify-between">
-            <div>
+            <div className="flex items-center gap-1">
               {currentStep > 0 && (
                 <Button
                   variant="ghost"
@@ -307,6 +307,14 @@ export function OnboardingDialog({
                   Back
                 </Button>
               )}
+              <Button
+                variant="link"
+                size="sm"
+                onClick={onComplete}
+                className="h-8 text-xs text-muted-foreground/60 hover:text-muted-foreground"
+              >
+                Skip tour
+              </Button>
             </div>
             <Button size="sm" onClick={handleNext} className="h-8 text-xs gap-1 px-4 shadow-sm">
               {isLastStep ? (

--- a/frontend/src/components/onboarding/OnboardingDialog.tsx
+++ b/frontend/src/components/onboarding/OnboardingDialog.tsx
@@ -10,6 +10,7 @@ import {
   ArrowRight,
   ArrowLeft,
   Sparkles,
+  X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -18,7 +19,8 @@ interface OnboardingStep {
   description: string;
   icon: typeof Sparkles;
   content: string;
-  color: string;
+  gradient: string;
+  iconColor: string;
   target: string | null;
 }
 
@@ -29,7 +31,8 @@ const ONBOARDING_STEPS: OnboardingStep[] = [
     icon: Sparkles,
     content:
       "ShipSec Studio is your all-in-one security automation platform. We'll walk you through the key features to get you started.",
-    color: 'text-purple-500',
+    gradient: 'from-purple-500/20 via-violet-500/10 to-transparent',
+    iconColor: 'text-purple-500',
     target: null,
   },
   {
@@ -38,7 +41,8 @@ const ONBOARDING_STEPS: OnboardingStep[] = [
     icon: Workflow,
     content:
       'Design powerful security workflows using the visual builder. Drag and drop nodes, configure actions, and chain them together.',
-    color: 'text-blue-500',
+    gradient: 'from-blue-500/20 via-blue-500/10 to-transparent',
+    iconColor: 'text-blue-500',
     target: '[data-onboarding="workflow-builder"]',
   },
   {
@@ -47,7 +51,8 @@ const ONBOARDING_STEPS: OnboardingStep[] = [
     icon: Package,
     content:
       'Browse ready-made workflow templates for common security tasks. Pick one and customize it to fit your needs.',
-    color: 'text-green-500',
+    gradient: 'from-green-500/20 via-green-500/10 to-transparent',
+    iconColor: 'text-green-500',
     target: '[data-onboarding="template-library"]',
   },
   {
@@ -56,7 +61,8 @@ const ONBOARDING_STEPS: OnboardingStep[] = [
     icon: CalendarClock,
     content:
       'Set up schedules to run workflows at specific intervals. Automate recurring security scans and checks effortlessly.',
-    color: 'text-orange-500',
+    gradient: 'from-orange-500/20 via-orange-500/10 to-transparent',
+    iconColor: 'text-orange-500',
     target: '[data-onboarding="schedules"]',
   },
   {
@@ -65,7 +71,8 @@ const ONBOARDING_STEPS: OnboardingStep[] = [
     icon: Zap,
     content:
       'Review workflow executions, inspect findings, and take action on results — all from one central dashboard.',
-    color: 'text-yellow-500',
+    gradient: 'from-yellow-500/20 via-yellow-500/10 to-transparent',
+    iconColor: 'text-yellow-500',
     target: '[data-onboarding="action-center"]',
   },
   {
@@ -74,14 +81,15 @@ const ONBOARDING_STEPS: OnboardingStep[] = [
     icon: KeyRound,
     content:
       'Store API keys, tokens, and credentials securely. Configure MCP servers and manage all your sensitive data from here.',
-    color: 'text-red-500',
+    gradient: 'from-red-500/20 via-red-500/10 to-transparent',
+    iconColor: 'text-red-500',
     target: '[data-onboarding="manage-section"]',
   },
 ];
 
-const SPOTLIGHT_PADDING = 8;
+const SPOTLIGHT_PADDING = 10;
 const TOOLTIP_GAP = 16;
-const TOOLTIP_WIDTH = 360;
+const TOOLTIP_WIDTH = 380;
 
 interface OnboardingDialogProps {
   open: boolean;
@@ -116,7 +124,6 @@ export function OnboardingDialog({
       return;
     }
 
-    // Delay to allow sidebar animations to settle
     const timer = setTimeout(() => {
       const el = document.querySelector(step.target!);
       if (el) {
@@ -124,7 +131,7 @@ export function OnboardingDialog({
       } else {
         setTargetRect(null);
       }
-    }, 350);
+    }, 120);
 
     return () => clearTimeout(timer);
   }, [open, step?.target, currentStep]);
@@ -181,7 +188,6 @@ export function OnboardingDialog({
 
   if (!open || !step) return null;
 
-  // Calculate tooltip position
   const getTooltipStyle = (): React.CSSProperties => {
     if (isCenter || !targetRect) {
       return {
@@ -192,15 +198,13 @@ export function OnboardingDialog({
       };
     }
 
-    // Position to the right of the highlighted element
     const tooltipTop = Math.max(
       16,
-      Math.min(window.innerHeight - 320, targetRect.top + targetRect.height / 2 - 100),
+      Math.min(window.innerHeight - 340, targetRect.top + targetRect.height / 2 - 100),
     );
 
     const tooltipLeft = targetRect.right + TOOLTIP_GAP;
 
-    // If tooltip would overflow right edge, position below instead
     if (tooltipLeft + TOOLTIP_WIDTH > window.innerWidth - 16) {
       return {
         top: targetRect.bottom + TOOLTIP_GAP,
@@ -223,29 +227,25 @@ export function OnboardingDialog({
       aria-modal="true"
       aria-label="Onboarding tour"
     >
-      {/* Click blocker overlay */}
       <div className="fixed inset-0" aria-hidden="true" />
 
-      {/* Dimming overlay or spotlight */}
       {isCenter || !targetRect ? (
-        <div className="fixed inset-0 bg-black/60 transition-opacity duration-300" />
+        <div className="fixed inset-0 bg-black/60 backdrop-blur-[2px] transition-opacity duration-200" />
       ) : (
         <>
-          {/* Spotlight cutout with smooth transition */}
           <div
-            className="fixed rounded-lg transition-all duration-500 ease-in-out"
+            className="fixed rounded-xl transition-all duration-300 ease-out"
             style={{
               top: targetRect.top - SPOTLIGHT_PADDING,
               left: targetRect.left - SPOTLIGHT_PADDING,
               width: targetRect.width + SPOTLIGHT_PADDING * 2,
               height: targetRect.height + SPOTLIGHT_PADDING * 2,
-              boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.6), 0 0 20px 4px rgba(59, 130, 246, 0.25)',
+              boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.6), 0 0 30px 8px rgba(99, 102, 241, 0.2)',
               pointerEvents: 'none',
             }}
           />
-          {/* Pulsing ring around spotlight */}
           <div
-            className="fixed rounded-lg border-2 border-primary/50 transition-all duration-500 ease-in-out animate-pulse"
+            className="fixed rounded-xl border-2 border-primary/40 transition-all duration-300 ease-out animate-pulse"
             style={{
               top: targetRect.top - SPOTLIGHT_PADDING - 2,
               left: targetRect.left - SPOTLIGHT_PADDING - 2,
@@ -260,81 +260,90 @@ export function OnboardingDialog({
       {/* Tooltip card */}
       <div
         ref={tooltipRef}
-        className={cn(
-          'fixed rounded-xl border bg-background shadow-2xl transition-all duration-300',
-          isCenter ? 'p-6' : 'p-5',
-        )}
+        className="fixed rounded-2xl border border-border/60 bg-background/95 backdrop-blur-xl shadow-2xl transition-all duration-200 overflow-hidden"
         style={getTooltipStyle()}
       >
-        {/* Progress indicator */}
-        <div className="flex items-center justify-center gap-1.5 mb-4" role="tablist">
-          {ONBOARDING_STEPS.map((s, index) => (
-            <button
-              key={index}
-              role="tab"
-              aria-selected={index === currentStep}
-              aria-label={`Step ${index + 1}: ${s.title}`}
-              onClick={() => onStepChange(index)}
-              className={cn(
-                'h-1.5 rounded-full transition-all duration-300 hover:opacity-80',
-                index <= currentStep ? 'bg-primary' : 'bg-muted',
-                index === currentStep ? 'w-6' : 'w-1.5',
-              )}
-            />
-          ))}
-        </div>
-
-        {/* Step content */}
-        <div key={currentStep} className="animate-in fade-in duration-200">
-          <div className="flex items-center gap-3 mb-3">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted">
-              <Icon className={cn('h-5 w-5', step.color)} />
-            </div>
-            <div className="min-w-0">
-              <h3 className="font-semibold text-foreground text-sm leading-tight">{step.title}</h3>
-              <p className="text-xs text-muted-foreground">{step.description}</p>
-            </div>
-          </div>
-
-          <p className="text-sm leading-relaxed text-muted-foreground mb-4">{step.content}</p>
-        </div>
-
-        {/* Navigation footer */}
-        <div className="flex items-center justify-between pt-1">
-          <Button
-            variant="ghost"
-            size="sm"
+        {/* Gradient header */}
+        <div className={cn('bg-gradient-to-br px-5 pt-5 pb-4', step.gradient)}>
+          {/* Close button */}
+          <button
             onClick={onComplete}
-            className="text-muted-foreground text-xs h-8"
+            className="absolute top-3 right-3 p-1 rounded-lg text-muted-foreground/60 hover:text-foreground hover:bg-muted/50 transition-colors"
+            aria-label="Close tour"
           >
-            Skip tour
-          </Button>
+            <X className="h-4 w-4" />
+          </button>
 
-          <div className="flex items-center gap-2">
-            {currentStep > 0 && (
-              <Button variant="outline" size="sm" onClick={handleBack} className="h-8 text-xs">
-                <ArrowLeft className="mr-1 h-3 w-3" />
-                Back
-              </Button>
-            )}
-            <Button size="sm" onClick={handleNext} className="h-8 text-xs">
-              {isLastStep ? (
-                'Get Started'
-              ) : (
-                <>
-                  Next
-                  <ArrowRight className="ml-1 h-3 w-3" />
-                </>
-              )}
-            </Button>
+          {/* Step content */}
+          <div key={currentStep} className="animate-in fade-in slide-in-from-bottom-2 duration-200">
+            <div className="flex items-start gap-3 mb-3">
+              <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-background/80 shadow-sm border border-border/40">
+                <Icon className={cn('h-5 w-5', step.iconColor)} />
+              </div>
+              <div className="min-w-0 pt-0.5">
+                <h3 className="font-semibold text-foreground text-[15px] leading-tight">
+                  {step.title}
+                </h3>
+                <p className="text-xs text-muted-foreground mt-0.5">{step.description}</p>
+              </div>
+            </div>
+
+            <p className="text-[13px] leading-relaxed text-muted-foreground">{step.content}</p>
           </div>
         </div>
 
-        {/* Step counter */}
-        <div className="text-center mt-2">
-          <span className="text-[11px] text-muted-foreground/70">
-            {currentStep + 1} of {ONBOARDING_STEPS.length}
-          </span>
+        {/* Footer */}
+        <div className="px-5 py-3 border-t border-border/40 bg-muted/20">
+          {/* Progress dots */}
+          <div className="flex items-center justify-center gap-1.5 mb-3" role="tablist">
+            {ONBOARDING_STEPS.map((s, index) => (
+              <button
+                key={index}
+                role="tab"
+                aria-selected={index === currentStep}
+                aria-label={`Step ${index + 1}: ${s.title}`}
+                onClick={() => onStepChange(index)}
+                className={cn(
+                  'rounded-full transition-all duration-200 hover:opacity-80',
+                  index === currentStep
+                    ? 'w-6 h-2 bg-primary'
+                    : index < currentStep
+                      ? 'w-2 h-2 bg-primary/50'
+                      : 'w-2 h-2 bg-muted-foreground/20',
+                )}
+              />
+            ))}
+          </div>
+
+          <div className="flex items-center justify-between">
+            <span className="text-[11px] text-muted-foreground/60 tabular-nums">
+              {currentStep + 1} / {ONBOARDING_STEPS.length}
+            </span>
+
+            <div className="flex items-center gap-2">
+              {currentStep > 0 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleBack}
+                  className="h-8 text-xs gap-1 text-muted-foreground hover:text-foreground"
+                >
+                  <ArrowLeft className="h-3 w-3" />
+                  Back
+                </Button>
+              )}
+              <Button size="sm" onClick={handleNext} className="h-8 text-xs gap-1 px-4 shadow-sm">
+                {isLastStep ? (
+                  'Get Started'
+                ) : (
+                  <>
+                    Next
+                    <ArrowRight className="h-3 w-3" />
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
         </div>
       </div>
     </div>,

--- a/frontend/src/components/onboarding/WorkflowBuilderTour.tsx
+++ b/frontend/src/components/onboarding/WorkflowBuilderTour.tsx
@@ -11,6 +11,7 @@ import {
   MoreVertical,
   ArrowRight,
   ArrowLeft,
+  X,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -19,7 +20,8 @@ interface BuilderTourStep {
   description: string;
   icon: typeof Sparkles;
   content: string;
-  color: string;
+  gradient: string;
+  iconColor: string;
   target: string | null;
 }
 
@@ -30,7 +32,8 @@ const BUILDER_TOUR_STEPS: BuilderTourStep[] = [
     icon: Sparkles,
     content:
       "This is where you design and execute security workflows. We'll walk you through each part of the builder interface.",
-    color: 'text-purple-500',
+    gradient: 'from-purple-500/20 via-violet-500/10 to-transparent',
+    iconColor: 'text-purple-500',
     target: null,
   },
   {
@@ -39,7 +42,8 @@ const BUILDER_TOUR_STEPS: BuilderTourStep[] = [
     icon: PanelLeft,
     content:
       'Browse available components here — entry points, actions, conditions, and more. Drag any component onto the canvas to add it to your workflow.',
-    color: 'text-blue-500',
+    gradient: 'from-blue-500/20 via-blue-500/10 to-transparent',
+    iconColor: 'text-blue-500',
     target: '[data-onboarding-builder="library-panel"]',
   },
   {
@@ -48,7 +52,8 @@ const BUILDER_TOUR_STEPS: BuilderTourStep[] = [
     icon: MousePointerSquareDashed,
     content:
       'This is where your workflow comes to life. Connect nodes by dragging from one handle to another. Pan and zoom to navigate larger workflows.',
-    color: 'text-emerald-500',
+    gradient: 'from-emerald-500/20 via-emerald-500/10 to-transparent',
+    iconColor: 'text-emerald-500',
     target: '[data-onboarding-builder="canvas"]',
   },
   {
@@ -57,7 +62,8 @@ const BUILDER_TOUR_STEPS: BuilderTourStep[] = [
     icon: PencilLine,
     content:
       'Use Design mode to build your workflow. Switch to Execute mode to run it, inspect past executions, and view real-time logs.',
-    color: 'text-indigo-500',
+    gradient: 'from-indigo-500/20 via-indigo-500/10 to-transparent',
+    iconColor: 'text-indigo-500',
     target: '[data-onboarding-builder="mode-toggle"]',
   },
   {
@@ -66,7 +72,8 @@ const BUILDER_TOUR_STEPS: BuilderTourStep[] = [
     icon: Save,
     content:
       'Save your workflow at any time. The status badge shows whether changes are synced, pending, or currently saving. Use Cmd+S for a quick save.',
-    color: 'text-amber-500',
+    gradient: 'from-amber-500/20 via-amber-500/10 to-transparent',
+    iconColor: 'text-amber-500',
     target: '[data-onboarding-builder="save-button"]',
   },
   {
@@ -75,7 +82,8 @@ const BUILDER_TOUR_STEPS: BuilderTourStep[] = [
     icon: Play,
     content:
       'Click Run to execute your workflow. If your workflow has runtime inputs, a dialog will prompt you to fill them in before execution starts.',
-    color: 'text-green-500',
+    gradient: 'from-green-500/20 via-green-500/10 to-transparent',
+    iconColor: 'text-green-500',
     target: '[data-onboarding-builder="run-button"]',
   },
   {
@@ -84,14 +92,15 @@ const BUILDER_TOUR_STEPS: BuilderTourStep[] = [
     icon: MoreVertical,
     content:
       'Access undo/redo (Cmd+Z / Cmd+Shift+Z), import workflows from JSON files, or export your current workflow for sharing and backup.',
-    color: 'text-red-500',
+    gradient: 'from-red-500/20 via-red-500/10 to-transparent',
+    iconColor: 'text-red-500',
     target: '[data-onboarding-builder="more-options"]',
   },
 ];
 
-const SPOTLIGHT_PADDING = 8;
+const SPOTLIGHT_PADDING = 10;
 const TOOLTIP_GAP = 16;
-const TOOLTIP_WIDTH = 360;
+const TOOLTIP_WIDTH = 380;
 
 interface WorkflowBuilderTourProps {
   open: boolean;
@@ -126,7 +135,6 @@ export function WorkflowBuilderTour({
       return;
     }
 
-    // Delay to allow panel animations to settle
     const timer = setTimeout(() => {
       const el = document.querySelector(step.target!);
       if (el) {
@@ -134,7 +142,7 @@ export function WorkflowBuilderTour({
       } else {
         setTargetRect(null);
       }
-    }, 350);
+    }, 120);
 
     return () => clearTimeout(timer);
   }, [open, step?.target, currentStep]);
@@ -191,7 +199,6 @@ export function WorkflowBuilderTour({
 
   if (!open || !step) return null;
 
-  // Calculate tooltip position
   const getTooltipStyle = (): React.CSSProperties => {
     if (isCenter || !targetRect) {
       return {
@@ -244,29 +251,25 @@ export function WorkflowBuilderTour({
       aria-modal="true"
       aria-label="Workflow Builder tour"
     >
-      {/* Click blocker overlay */}
       <div className="fixed inset-0" aria-hidden="true" />
 
-      {/* Dimming overlay or spotlight */}
       {isCenter || !targetRect ? (
-        <div className="fixed inset-0 bg-black/60 transition-opacity duration-300" />
+        <div className="fixed inset-0 bg-black/60 backdrop-blur-[2px] transition-opacity duration-200" />
       ) : (
         <>
-          {/* Spotlight cutout with smooth transition */}
           <div
-            className="fixed rounded-lg transition-all duration-500 ease-in-out"
+            className="fixed rounded-xl transition-all duration-300 ease-out"
             style={{
               top: targetRect.top - SPOTLIGHT_PADDING,
               left: targetRect.left - SPOTLIGHT_PADDING,
               width: targetRect.width + SPOTLIGHT_PADDING * 2,
               height: targetRect.height + SPOTLIGHT_PADDING * 2,
-              boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.6), 0 0 20px 4px rgba(59, 130, 246, 0.25)',
+              boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.6), 0 0 30px 8px rgba(99, 102, 241, 0.2)',
               pointerEvents: 'none',
             }}
           />
-          {/* Pulsing ring around spotlight */}
           <div
-            className="fixed rounded-lg border-2 border-primary/50 transition-all duration-500 ease-in-out animate-pulse"
+            className="fixed rounded-xl border-2 border-primary/40 transition-all duration-300 ease-out animate-pulse"
             style={{
               top: targetRect.top - SPOTLIGHT_PADDING - 2,
               left: targetRect.left - SPOTLIGHT_PADDING - 2,
@@ -281,81 +284,90 @@ export function WorkflowBuilderTour({
       {/* Tooltip card */}
       <div
         ref={tooltipRef}
-        className={cn(
-          'fixed rounded-xl border bg-background shadow-2xl transition-all duration-300',
-          isCenter ? 'p-6' : 'p-5',
-        )}
+        className="fixed rounded-2xl border border-border/60 bg-background/95 backdrop-blur-xl shadow-2xl transition-all duration-200 overflow-hidden"
         style={getTooltipStyle()}
       >
-        {/* Progress indicator */}
-        <div className="flex items-center justify-center gap-1.5 mb-4" role="tablist">
-          {BUILDER_TOUR_STEPS.map((s, index) => (
-            <button
-              key={index}
-              role="tab"
-              aria-selected={index === currentStep}
-              aria-label={`Step ${index + 1}: ${s.title}`}
-              onClick={() => onStepChange(index)}
-              className={cn(
-                'h-1.5 rounded-full transition-all duration-300 hover:opacity-80',
-                index <= currentStep ? 'bg-primary' : 'bg-muted',
-                index === currentStep ? 'w-6' : 'w-1.5',
-              )}
-            />
-          ))}
-        </div>
-
-        {/* Step content */}
-        <div key={currentStep} className="animate-in fade-in duration-200">
-          <div className="flex items-center gap-3 mb-3">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted">
-              <Icon className={cn('h-5 w-5', step.color)} />
-            </div>
-            <div className="min-w-0">
-              <h3 className="font-semibold text-foreground text-sm leading-tight">{step.title}</h3>
-              <p className="text-xs text-muted-foreground">{step.description}</p>
-            </div>
-          </div>
-
-          <p className="text-sm leading-relaxed text-muted-foreground mb-4">{step.content}</p>
-        </div>
-
-        {/* Navigation footer */}
-        <div className="flex items-center justify-between pt-1">
-          <Button
-            variant="ghost"
-            size="sm"
+        {/* Gradient header */}
+        <div className={cn('bg-gradient-to-br px-5 pt-5 pb-4', step.gradient)}>
+          {/* Close button */}
+          <button
             onClick={onComplete}
-            className="text-muted-foreground text-xs h-8"
+            className="absolute top-3 right-3 p-1 rounded-lg text-muted-foreground/60 hover:text-foreground hover:bg-muted/50 transition-colors"
+            aria-label="Close tour"
           >
-            Skip tour
-          </Button>
+            <X className="h-4 w-4" />
+          </button>
 
-          <div className="flex items-center gap-2">
-            {currentStep > 0 && (
-              <Button variant="outline" size="sm" onClick={handleBack} className="h-8 text-xs">
-                <ArrowLeft className="mr-1 h-3 w-3" />
-                Back
-              </Button>
-            )}
-            <Button size="sm" onClick={handleNext} className="h-8 text-xs">
-              {isLastStep ? (
-                'Start Building'
-              ) : (
-                <>
-                  Next
-                  <ArrowRight className="ml-1 h-3 w-3" />
-                </>
-              )}
-            </Button>
+          {/* Step content */}
+          <div key={currentStep} className="animate-in fade-in slide-in-from-bottom-2 duration-200">
+            <div className="flex items-start gap-3 mb-3">
+              <div className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-background/80 shadow-sm border border-border/40">
+                <Icon className={cn('h-5 w-5', step.iconColor)} />
+              </div>
+              <div className="min-w-0 pt-0.5">
+                <h3 className="font-semibold text-foreground text-[15px] leading-tight">
+                  {step.title}
+                </h3>
+                <p className="text-xs text-muted-foreground mt-0.5">{step.description}</p>
+              </div>
+            </div>
+
+            <p className="text-[13px] leading-relaxed text-muted-foreground">{step.content}</p>
           </div>
         </div>
 
-        {/* Step counter */}
-        <div className="text-center mt-2">
-          <span className="text-[11px] text-muted-foreground/70">
-            {currentStep + 1} of {BUILDER_TOUR_STEPS.length}
-          </span>
+        {/* Footer */}
+        <div className="px-5 py-3 border-t border-border/40 bg-muted/20">
+          {/* Progress dots */}
+          <div className="flex items-center justify-center gap-1.5 mb-3" role="tablist">
+            {BUILDER_TOUR_STEPS.map((s, index) => (
+              <button
+                key={index}
+                role="tab"
+                aria-selected={index === currentStep}
+                aria-label={`Step ${index + 1}: ${s.title}`}
+                onClick={() => onStepChange(index)}
+                className={cn(
+                  'rounded-full transition-all duration-200 hover:opacity-80',
+                  index === currentStep
+                    ? 'w-6 h-2 bg-primary'
+                    : index < currentStep
+                      ? 'w-2 h-2 bg-primary/50'
+                      : 'w-2 h-2 bg-muted-foreground/20',
+                )}
+              />
+            ))}
+          </div>
+
+          <div className="flex items-center justify-between">
+            <span className="text-[11px] text-muted-foreground/60 tabular-nums">
+              {currentStep + 1} / {BUILDER_TOUR_STEPS.length}
+            </span>
+
+            <div className="flex items-center gap-2">
+              {currentStep > 0 && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  onClick={handleBack}
+                  className="h-8 text-xs gap-1 text-muted-foreground hover:text-foreground"
+                >
+                  <ArrowLeft className="h-3 w-3" />
+                  Back
+                </Button>
+              )}
+              <Button size="sm" onClick={handleNext} className="h-8 text-xs gap-1 px-4 shadow-sm">
+                {isLastStep ? (
+                  'Start Building'
+                ) : (
+                  <>
+                    Next
+                    <ArrowRight className="h-3 w-3" />
+                  </>
+                )}
+              </Button>
+            </div>
+          </div>
         </div>
       </div>
     </div>,

--- a/frontend/src/components/onboarding/WorkflowBuilderTour.tsx
+++ b/frontend/src/components/onboarding/WorkflowBuilderTour.tsx
@@ -12,6 +12,9 @@ import {
   ArrowRight,
   ArrowLeft,
   X,
+  MonitorPlay,
+  LayoutList,
+  CalendarClock,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
@@ -95,6 +98,36 @@ const BUILDER_TOUR_STEPS: BuilderTourStep[] = [
     gradient: 'from-red-500/20 via-red-500/10 to-transparent',
     iconColor: 'text-red-500',
     target: '[data-onboarding-builder="more-options"]',
+  },
+  {
+    title: 'Execution Inspector',
+    description: 'Monitor your workflow runs.',
+    icon: MonitorPlay,
+    content:
+      'Switch to Execute mode to see this panel. Select a run to explore its timeline, view real-time progress, rerun workflows, and stop active executions.',
+    gradient: 'from-cyan-500/20 via-cyan-500/10 to-transparent',
+    iconColor: 'text-cyan-500',
+    target: '[data-onboarding-builder="execution-inspector"]',
+  },
+  {
+    title: 'Inspector Tabs',
+    description: 'Events, Logs, Agent, Artifacts, I/O & Network.',
+    icon: LayoutList,
+    content:
+      'Dive deep into each run with six inspector tabs — view execution events, stream logs in real-time, trace agent activity, browse artifacts, inspect node I/O, and monitor network calls.',
+    gradient: 'from-violet-500/20 via-violet-500/10 to-transparent',
+    iconColor: 'text-violet-500',
+    target: '[data-onboarding-builder="inspector-tabs"]',
+  },
+  {
+    title: 'Schedules',
+    description: 'Automate recurring workflow runs.',
+    icon: CalendarClock,
+    content:
+      'Create and manage schedules to run your workflow automatically at set intervals. View active, paused, and errored schedules right from the canvas.',
+    gradient: 'from-teal-500/20 via-teal-500/10 to-transparent',
+    iconColor: 'text-teal-500',
+    target: '[data-onboarding-builder="schedule-bar"]',
   },
 ];
 

--- a/frontend/src/components/onboarding/WorkflowBuilderTour.tsx
+++ b/frontend/src/components/onboarding/WorkflowBuilderTour.tsx
@@ -15,8 +15,10 @@ import {
   MonitorPlay,
   LayoutList,
   CalendarClock,
+  Package,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import { useWorkflowUiStore } from '@/store/workflowUiStore';
 
 interface BuilderTourStep {
   title: string;
@@ -26,6 +28,7 @@ interface BuilderTourStep {
   gradient: string;
   iconColor: string;
   target: string | null;
+  requiresMode?: 'design' | 'execution';
 }
 
 const BUILDER_TOUR_STEPS: BuilderTourStep[] = [
@@ -90,6 +93,16 @@ const BUILDER_TOUR_STEPS: BuilderTourStep[] = [
     target: '[data-onboarding-builder="run-button"]',
   },
   {
+    title: 'Publish as Template',
+    description: 'Share your workflow with the team.',
+    icon: Package,
+    content:
+      'Use the dropdown arrow next to the Run button to publish your workflow as a reusable template. Others in your organization can use it as a starting point.',
+    gradient: 'from-orange-500/20 via-orange-500/10 to-transparent',
+    iconColor: 'text-orange-500',
+    target: '[data-onboarding-builder="publish-trigger"]',
+  },
+  {
     title: 'More Options',
     description: 'Undo, Redo, Import & Export.',
     icon: MoreVertical,
@@ -100,14 +113,25 @@ const BUILDER_TOUR_STEPS: BuilderTourStep[] = [
     target: '[data-onboarding-builder="more-options"]',
   },
   {
+    title: 'Schedules',
+    description: 'Automate recurring workflow runs.',
+    icon: CalendarClock,
+    content:
+      'Create and manage schedules to run your workflow automatically at set intervals. View active, paused, and errored schedules right from the canvas.',
+    gradient: 'from-teal-500/20 via-teal-500/10 to-transparent',
+    iconColor: 'text-teal-500',
+    target: '[data-onboarding-builder="schedule-bar"]',
+  },
+  {
     title: 'Execution Inspector',
     description: 'Monitor your workflow runs.',
     icon: MonitorPlay,
     content:
-      'Switch to Execute mode to see this panel. Select a run to explore its timeline, view real-time progress, rerun workflows, and stop active executions.',
+      'This panel shows all your workflow runs. Select a run to explore its timeline, view real-time progress, rerun workflows, and stop active executions.',
     gradient: 'from-cyan-500/20 via-cyan-500/10 to-transparent',
     iconColor: 'text-cyan-500',
     target: '[data-onboarding-builder="execution-inspector"]',
+    requiresMode: 'execution',
   },
   {
     title: 'Inspector Tabs',
@@ -118,16 +142,7 @@ const BUILDER_TOUR_STEPS: BuilderTourStep[] = [
     gradient: 'from-violet-500/20 via-violet-500/10 to-transparent',
     iconColor: 'text-violet-500',
     target: '[data-onboarding-builder="inspector-tabs"]',
-  },
-  {
-    title: 'Schedules',
-    description: 'Automate recurring workflow runs.',
-    icon: CalendarClock,
-    content:
-      'Create and manage schedules to run your workflow automatically at set intervals. View active, paused, and errored schedules right from the canvas.',
-    gradient: 'from-teal-500/20 via-teal-500/10 to-transparent',
-    iconColor: 'text-teal-500',
-    target: '[data-onboarding-builder="schedule-bar"]',
+    requiresMode: 'execution',
   },
 ];
 
@@ -156,6 +171,20 @@ export function WorkflowBuilderTour({
   const Icon = step?.icon ?? Sparkles;
   const isCenter = !step?.target;
 
+  // Auto-switch mode based on step requirements
+  useEffect(() => {
+    if (!open || !step) return;
+
+    const store = useWorkflowUiStore.getState();
+    const requiredMode = step.requiresMode;
+
+    if (requiredMode === 'execution' && store.mode !== 'execution') {
+      store.setMode('execution');
+    } else if (requiredMode !== 'execution' && store.mode === 'execution') {
+      store.setMode('design');
+    }
+  }, [open, currentStep, step]);
+
   // Track target element position
   useEffect(() => {
     if (!open) {
@@ -168,6 +197,9 @@ export function WorkflowBuilderTour({
       return;
     }
 
+    // Use longer delay for steps that require a mode switch to allow re-render
+    const delay = step.requiresMode ? 250 : 120;
+
     const timer = setTimeout(() => {
       const el = document.querySelector(step.target!);
       if (el) {
@@ -175,10 +207,10 @@ export function WorkflowBuilderTour({
       } else {
         setTargetRect(null);
       }
-    }, 120);
+    }, delay);
 
     return () => clearTimeout(timer);
-  }, [open, step?.target, currentStep]);
+  }, [open, step?.target, step?.requiresMode, currentStep]);
 
   // Update on window resize
   useEffect(() => {
@@ -195,13 +227,22 @@ export function WorkflowBuilderTour({
     return () => window.removeEventListener('resize', updateRect);
   }, [open, step?.target]);
 
+  // Wrap onComplete to restore design mode if needed
+  const handleComplete = useCallback(() => {
+    const currentMode = useWorkflowUiStore.getState().mode;
+    if (currentMode === 'execution') {
+      useWorkflowUiStore.getState().setMode('design');
+    }
+    onComplete();
+  }, [onComplete]);
+
   const handleNext = useCallback(() => {
     if (isLastStep) {
-      onComplete();
+      handleComplete();
     } else {
       onStepChange(currentStep + 1);
     }
-  }, [isLastStep, onComplete, onStepChange, currentStep]);
+  }, [isLastStep, handleComplete, onStepChange, currentStep]);
 
   const handleBack = useCallback(() => {
     if (currentStep > 0) {
@@ -222,13 +263,13 @@ export function WorkflowBuilderTour({
         handleBack();
       } else if (e.key === 'Escape') {
         e.preventDefault();
-        onComplete();
+        handleComplete();
       }
     };
 
     document.addEventListener('keydown', handleKeyDown);
     return () => document.removeEventListener('keydown', handleKeyDown);
-  }, [open, handleNext, handleBack, onComplete]);
+  }, [open, handleNext, handleBack, handleComplete]);
 
   if (!open || !step) return null;
 
@@ -257,6 +298,19 @@ export function WorkflowBuilderTour({
       return {
         top: tooltipTop,
         left: targetRect.right + TOOLTIP_GAP,
+        width: TOOLTIP_WIDTH,
+      };
+    }
+
+    // For inspector elements (right panel), position to the left
+    if (
+      step.target === '[data-onboarding-builder="execution-inspector"]' ||
+      step.target === '[data-onboarding-builder="inspector-tabs"]'
+    ) {
+      const tooltipTop = Math.max(80, targetRect.top + targetRect.height / 2 - 100);
+      return {
+        top: tooltipTop,
+        left: targetRect.left - TOOLTIP_WIDTH - TOOLTIP_GAP,
         width: TOOLTIP_WIDTH,
       };
     }
@@ -324,7 +378,7 @@ export function WorkflowBuilderTour({
         <div className={cn('bg-gradient-to-br px-5 pt-5 pb-4', step.gradient)}>
           {/* Close button */}
           <button
-            onClick={onComplete}
+            onClick={handleComplete}
             className="absolute top-3 right-3 p-1 rounded-lg text-muted-foreground/60 hover:text-foreground hover:bg-muted/50 transition-colors"
             aria-label="Close tour"
           >
@@ -351,33 +405,8 @@ export function WorkflowBuilderTour({
 
         {/* Footer */}
         <div className="px-5 py-3 border-t border-border/40 bg-muted/20">
-          {/* Progress dots */}
-          <div className="flex items-center justify-center gap-1.5 mb-3" role="tablist">
-            {BUILDER_TOUR_STEPS.map((s, index) => (
-              <button
-                key={index}
-                role="tab"
-                aria-selected={index === currentStep}
-                aria-label={`Step ${index + 1}: ${s.title}`}
-                onClick={() => onStepChange(index)}
-                className={cn(
-                  'rounded-full transition-all duration-200 hover:opacity-80',
-                  index === currentStep
-                    ? 'w-6 h-2 bg-primary'
-                    : index < currentStep
-                      ? 'w-2 h-2 bg-primary/50'
-                      : 'w-2 h-2 bg-muted-foreground/20',
-                )}
-              />
-            ))}
-          </div>
-
           <div className="flex items-center justify-between">
-            <span className="text-[11px] text-muted-foreground/60 tabular-nums">
-              {currentStep + 1} / {BUILDER_TOUR_STEPS.length}
-            </span>
-
-            <div className="flex items-center gap-2">
+            <div>
               {currentStep > 0 && (
                 <Button
                   variant="ghost"
@@ -389,17 +418,17 @@ export function WorkflowBuilderTour({
                   Back
                 </Button>
               )}
-              <Button size="sm" onClick={handleNext} className="h-8 text-xs gap-1 px-4 shadow-sm">
-                {isLastStep ? (
-                  'Start Building'
-                ) : (
-                  <>
-                    Next
-                    <ArrowRight className="h-3 w-3" />
-                  </>
-                )}
-              </Button>
             </div>
+            <Button size="sm" onClick={handleNext} className="h-8 text-xs gap-1 px-4 shadow-sm">
+              {isLastStep ? (
+                'Start Building'
+              ) : (
+                <>
+                  Next
+                  <ArrowRight className="h-3 w-3" />
+                </>
+              )}
+            </Button>
           </div>
         </div>
       </div>

--- a/frontend/src/components/onboarding/WorkflowBuilderTour.tsx
+++ b/frontend/src/components/onboarding/WorkflowBuilderTour.tsx
@@ -2,7 +2,6 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 import { createPortal } from 'react-dom';
 import { Button } from '@/components/ui/button';
 import {
-  Sparkles,
   PanelLeft,
   MousePointerSquareDashed,
   PencilLine,
@@ -15,7 +14,6 @@ import {
   MonitorPlay,
   LayoutList,
   CalendarClock,
-  Package,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useWorkflowUiStore } from '@/store/workflowUiStore';
@@ -23,7 +21,7 @@ import { useWorkflowUiStore } from '@/store/workflowUiStore';
 interface BuilderTourStep {
   title: string;
   description: string;
-  icon: typeof Sparkles;
+  icon: typeof PanelLeft;
   content: string;
   gradient: string;
   iconColor: string;
@@ -32,16 +30,6 @@ interface BuilderTourStep {
 }
 
 const BUILDER_TOUR_STEPS: BuilderTourStep[] = [
-  {
-    title: 'Welcome to the Workflow Builder!',
-    description: "Let's explore how to build workflows.",
-    icon: Sparkles,
-    content:
-      "This is where you design and execute security workflows. We'll walk you through each part of the builder interface.",
-    gradient: 'from-purple-500/20 via-violet-500/10 to-transparent',
-    iconColor: 'text-purple-500',
-    target: null,
-  },
   {
     title: 'Component Library',
     description: 'Drag and drop nodes onto the canvas.',
@@ -93,21 +81,11 @@ const BUILDER_TOUR_STEPS: BuilderTourStep[] = [
     target: '[data-onboarding-builder="run-button"]',
   },
   {
-    title: 'Publish as Template',
-    description: 'Share your workflow with the team.',
-    icon: Package,
-    content:
-      'Use the dropdown arrow next to the Run button to publish your workflow as a reusable template. Others in your organization can use it as a starting point.',
-    gradient: 'from-orange-500/20 via-orange-500/10 to-transparent',
-    iconColor: 'text-orange-500',
-    target: '[data-onboarding-builder="publish-trigger"]',
-  },
-  {
     title: 'More Options',
-    description: 'Undo, Redo, Import & Export.',
+    description: 'Publish, Analytics, Import & Export.',
     icon: MoreVertical,
     content:
-      'Access undo/redo (Cmd+Z / Cmd+Shift+Z), import workflows from JSON files, or export your current workflow for sharing and backup.',
+      'Access undo/redo, publish your workflow as a reusable template, view analytics dashboards, and import/export workflows as JSON.',
     gradient: 'from-red-500/20 via-red-500/10 to-transparent',
     iconColor: 'text-red-500',
     target: '[data-onboarding-builder="more-options"]',
@@ -168,7 +146,7 @@ export function WorkflowBuilderTour({
 
   const step = BUILDER_TOUR_STEPS[currentStep];
   const isLastStep = currentStep === BUILDER_TOUR_STEPS.length - 1;
-  const Icon = step?.icon ?? Sparkles;
+  const Icon = step?.icon ?? PanelLeft;
   const isCenter = !step?.target;
 
   // Auto-switch mode based on step requirements
@@ -302,15 +280,26 @@ export function WorkflowBuilderTour({
       };
     }
 
-    // For inspector elements (right panel), position to the left
+    // For inspector elements (right panel), position to the left with bounds checking
     if (
       step.target === '[data-onboarding-builder="execution-inspector"]' ||
       step.target === '[data-onboarding-builder="inspector-tabs"]'
     ) {
       const tooltipTop = Math.max(80, targetRect.top + targetRect.height / 2 - 100);
+      const leftPos = targetRect.left - TOOLTIP_WIDTH - TOOLTIP_GAP;
+
+      // If tooltip would go off-screen left, center it over the canvas area instead
+      if (leftPos < 16) {
+        return {
+          top: tooltipTop,
+          left: Math.max(16, (targetRect.left - TOOLTIP_WIDTH) / 2),
+          width: Math.min(TOOLTIP_WIDTH, targetRect.left - 32),
+        };
+      }
+
       return {
         top: tooltipTop,
-        left: targetRect.left - TOOLTIP_WIDTH - TOOLTIP_GAP,
+        left: leftPos,
         width: TOOLTIP_WIDTH,
       };
     }

--- a/frontend/src/components/onboarding/WorkflowBuilderTour.tsx
+++ b/frontend/src/components/onboarding/WorkflowBuilderTour.tsx
@@ -1,0 +1,364 @@
+import { useState, useEffect, useCallback, useRef } from 'react';
+import { createPortal } from 'react-dom';
+import { Button } from '@/components/ui/button';
+import {
+  Sparkles,
+  PanelLeft,
+  MousePointerSquareDashed,
+  PencilLine,
+  Save,
+  Play,
+  MoreVertical,
+  ArrowRight,
+  ArrowLeft,
+} from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+interface BuilderTourStep {
+  title: string;
+  description: string;
+  icon: typeof Sparkles;
+  content: string;
+  color: string;
+  target: string | null;
+}
+
+const BUILDER_TOUR_STEPS: BuilderTourStep[] = [
+  {
+    title: 'Welcome to the Workflow Builder!',
+    description: "Let's explore how to build workflows.",
+    icon: Sparkles,
+    content:
+      "This is where you design and execute security workflows. We'll walk you through each part of the builder interface.",
+    color: 'text-purple-500',
+    target: null,
+  },
+  {
+    title: 'Component Library',
+    description: 'Drag and drop nodes onto the canvas.',
+    icon: PanelLeft,
+    content:
+      'Browse available components here — entry points, actions, conditions, and more. Drag any component onto the canvas to add it to your workflow.',
+    color: 'text-blue-500',
+    target: '[data-onboarding-builder="library-panel"]',
+  },
+  {
+    title: 'Canvas',
+    description: 'Your workflow design surface.',
+    icon: MousePointerSquareDashed,
+    content:
+      'This is where your workflow comes to life. Connect nodes by dragging from one handle to another. Pan and zoom to navigate larger workflows.',
+    color: 'text-emerald-500',
+    target: '[data-onboarding-builder="canvas"]',
+  },
+  {
+    title: 'Design & Execute Modes',
+    description: 'Switch between building and running.',
+    icon: PencilLine,
+    content:
+      'Use Design mode to build your workflow. Switch to Execute mode to run it, inspect past executions, and view real-time logs.',
+    color: 'text-indigo-500',
+    target: '[data-onboarding-builder="mode-toggle"]',
+  },
+  {
+    title: 'Save Workflow',
+    description: 'Persist your changes.',
+    icon: Save,
+    content:
+      'Save your workflow at any time. The status badge shows whether changes are synced, pending, or currently saving. Use Cmd+S for a quick save.',
+    color: 'text-amber-500',
+    target: '[data-onboarding-builder="save-button"]',
+  },
+  {
+    title: 'Run Workflow',
+    description: 'Execute your workflow instantly.',
+    icon: Play,
+    content:
+      'Click Run to execute your workflow. If your workflow has runtime inputs, a dialog will prompt you to fill them in before execution starts.',
+    color: 'text-green-500',
+    target: '[data-onboarding-builder="run-button"]',
+  },
+  {
+    title: 'More Options',
+    description: 'Undo, Redo, Import & Export.',
+    icon: MoreVertical,
+    content:
+      'Access undo/redo (Cmd+Z / Cmd+Shift+Z), import workflows from JSON files, or export your current workflow for sharing and backup.',
+    color: 'text-red-500',
+    target: '[data-onboarding-builder="more-options"]',
+  },
+];
+
+const SPOTLIGHT_PADDING = 8;
+const TOOLTIP_GAP = 16;
+const TOOLTIP_WIDTH = 360;
+
+interface WorkflowBuilderTourProps {
+  open: boolean;
+  onComplete: () => void;
+  currentStep: number;
+  onStepChange: (step: number) => void;
+}
+
+export function WorkflowBuilderTour({
+  open,
+  onComplete,
+  currentStep,
+  onStepChange,
+}: WorkflowBuilderTourProps) {
+  const [targetRect, setTargetRect] = useState<DOMRect | null>(null);
+  const tooltipRef = useRef<HTMLDivElement>(null);
+
+  const step = BUILDER_TOUR_STEPS[currentStep];
+  const isLastStep = currentStep === BUILDER_TOUR_STEPS.length - 1;
+  const Icon = step?.icon ?? Sparkles;
+  const isCenter = !step?.target;
+
+  // Track target element position
+  useEffect(() => {
+    if (!open) {
+      setTargetRect(null);
+      return;
+    }
+
+    if (!step?.target) {
+      setTargetRect(null);
+      return;
+    }
+
+    // Delay to allow panel animations to settle
+    const timer = setTimeout(() => {
+      const el = document.querySelector(step.target!);
+      if (el) {
+        setTargetRect(el.getBoundingClientRect());
+      } else {
+        setTargetRect(null);
+      }
+    }, 350);
+
+    return () => clearTimeout(timer);
+  }, [open, step?.target, currentStep]);
+
+  // Update on window resize
+  useEffect(() => {
+    if (!open || !step?.target) return;
+
+    const updateRect = () => {
+      const el = document.querySelector(step.target!);
+      if (el) {
+        setTargetRect(el.getBoundingClientRect());
+      }
+    };
+
+    window.addEventListener('resize', updateRect);
+    return () => window.removeEventListener('resize', updateRect);
+  }, [open, step?.target]);
+
+  const handleNext = useCallback(() => {
+    if (isLastStep) {
+      onComplete();
+    } else {
+      onStepChange(currentStep + 1);
+    }
+  }, [isLastStep, onComplete, onStepChange, currentStep]);
+
+  const handleBack = useCallback(() => {
+    if (currentStep > 0) {
+      onStepChange(currentStep - 1);
+    }
+  }, [currentStep, onStepChange]);
+
+  // Global keyboard handler
+  useEffect(() => {
+    if (!open) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'ArrowRight') {
+        e.preventDefault();
+        handleNext();
+      } else if (e.key === 'ArrowLeft') {
+        e.preventDefault();
+        handleBack();
+      } else if (e.key === 'Escape') {
+        e.preventDefault();
+        onComplete();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [open, handleNext, handleBack, onComplete]);
+
+  if (!open || !step) return null;
+
+  // Calculate tooltip position
+  const getTooltipStyle = (): React.CSSProperties => {
+    if (isCenter || !targetRect) {
+      return {
+        top: '50%',
+        left: '50%',
+        transform: 'translate(-50%, -50%)',
+        width: TOOLTIP_WIDTH,
+      };
+    }
+
+    // For the canvas (large element), position in the center of it
+    if (step.target === '[data-onboarding-builder="canvas"]') {
+      return {
+        top: targetRect.top + targetRect.height / 2 - 100,
+        left: targetRect.left + targetRect.width / 2 - TOOLTIP_WIDTH / 2,
+        width: TOOLTIP_WIDTH,
+      };
+    }
+
+    // For the library panel, position to the right
+    if (step.target === '[data-onboarding-builder="library-panel"]') {
+      const tooltipTop = Math.max(80, targetRect.top + targetRect.height / 2 - 100);
+      return {
+        top: tooltipTop,
+        left: targetRect.right + TOOLTIP_GAP,
+        width: TOOLTIP_WIDTH,
+      };
+    }
+
+    // For top-bar elements, position below
+    const tooltipLeft = Math.max(
+      16,
+      Math.min(
+        window.innerWidth - TOOLTIP_WIDTH - 16,
+        targetRect.left + targetRect.width / 2 - TOOLTIP_WIDTH / 2,
+      ),
+    );
+
+    return {
+      top: targetRect.bottom + TOOLTIP_GAP,
+      left: tooltipLeft,
+      width: TOOLTIP_WIDTH,
+    };
+  };
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[200]"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Workflow Builder tour"
+    >
+      {/* Click blocker overlay */}
+      <div className="fixed inset-0" aria-hidden="true" />
+
+      {/* Dimming overlay or spotlight */}
+      {isCenter || !targetRect ? (
+        <div className="fixed inset-0 bg-black/60 transition-opacity duration-300" />
+      ) : (
+        <>
+          {/* Spotlight cutout with smooth transition */}
+          <div
+            className="fixed rounded-lg transition-all duration-500 ease-in-out"
+            style={{
+              top: targetRect.top - SPOTLIGHT_PADDING,
+              left: targetRect.left - SPOTLIGHT_PADDING,
+              width: targetRect.width + SPOTLIGHT_PADDING * 2,
+              height: targetRect.height + SPOTLIGHT_PADDING * 2,
+              boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.6), 0 0 20px 4px rgba(59, 130, 246, 0.25)',
+              pointerEvents: 'none',
+            }}
+          />
+          {/* Pulsing ring around spotlight */}
+          <div
+            className="fixed rounded-lg border-2 border-primary/50 transition-all duration-500 ease-in-out animate-pulse"
+            style={{
+              top: targetRect.top - SPOTLIGHT_PADDING - 2,
+              left: targetRect.left - SPOTLIGHT_PADDING - 2,
+              width: targetRect.width + SPOTLIGHT_PADDING * 2 + 4,
+              height: targetRect.height + SPOTLIGHT_PADDING * 2 + 4,
+              pointerEvents: 'none',
+            }}
+          />
+        </>
+      )}
+
+      {/* Tooltip card */}
+      <div
+        ref={tooltipRef}
+        className={cn(
+          'fixed rounded-xl border bg-background shadow-2xl transition-all duration-300',
+          isCenter ? 'p-6' : 'p-5',
+        )}
+        style={getTooltipStyle()}
+      >
+        {/* Progress indicator */}
+        <div className="flex items-center justify-center gap-1.5 mb-4" role="tablist">
+          {BUILDER_TOUR_STEPS.map((s, index) => (
+            <button
+              key={index}
+              role="tab"
+              aria-selected={index === currentStep}
+              aria-label={`Step ${index + 1}: ${s.title}`}
+              onClick={() => onStepChange(index)}
+              className={cn(
+                'h-1.5 rounded-full transition-all duration-300 hover:opacity-80',
+                index <= currentStep ? 'bg-primary' : 'bg-muted',
+                index === currentStep ? 'w-6' : 'w-1.5',
+              )}
+            />
+          ))}
+        </div>
+
+        {/* Step content */}
+        <div key={currentStep} className="animate-in fade-in duration-200">
+          <div className="flex items-center gap-3 mb-3">
+            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-muted">
+              <Icon className={cn('h-5 w-5', step.color)} />
+            </div>
+            <div className="min-w-0">
+              <h3 className="font-semibold text-foreground text-sm leading-tight">{step.title}</h3>
+              <p className="text-xs text-muted-foreground">{step.description}</p>
+            </div>
+          </div>
+
+          <p className="text-sm leading-relaxed text-muted-foreground mb-4">{step.content}</p>
+        </div>
+
+        {/* Navigation footer */}
+        <div className="flex items-center justify-between pt-1">
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={onComplete}
+            className="text-muted-foreground text-xs h-8"
+          >
+            Skip tour
+          </Button>
+
+          <div className="flex items-center gap-2">
+            {currentStep > 0 && (
+              <Button variant="outline" size="sm" onClick={handleBack} className="h-8 text-xs">
+                <ArrowLeft className="mr-1 h-3 w-3" />
+                Back
+              </Button>
+            )}
+            <Button size="sm" onClick={handleNext} className="h-8 text-xs">
+              {isLastStep ? (
+                'Start Building'
+              ) : (
+                <>
+                  Next
+                  <ArrowRight className="ml-1 h-3 w-3" />
+                </>
+              )}
+            </Button>
+          </div>
+        </div>
+
+        {/* Step counter */}
+        <div className="text-center mt-2">
+          <span className="text-[11px] text-muted-foreground/70">
+            {currentStep + 1} of {BUILDER_TOUR_STEPS.length}
+          </span>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/frontend/src/components/onboarding/WorkflowBuilderTour.tsx
+++ b/frontend/src/components/onboarding/WorkflowBuilderTour.tsx
@@ -127,6 +127,7 @@ const BUILDER_TOUR_STEPS: BuilderTourStep[] = [
 const SPOTLIGHT_PADDING = 10;
 const TOOLTIP_GAP = 16;
 const TOOLTIP_WIDTH = 380;
+const TOOLTIP_WIDTH_NARROW = 320;
 
 interface WorkflowBuilderTourProps {
   open: boolean;
@@ -163,7 +164,8 @@ export function WorkflowBuilderTour({
     }
   }, [open, currentStep, step]);
 
-  // Track target element position
+  // Continuously track target element position using requestAnimationFrame
+  // This handles animations, transitions, resizes, and layout shifts automatically
   useEffect(() => {
     if (!open) {
       setTargetRect(null);
@@ -175,35 +177,46 @@ export function WorkflowBuilderTour({
       return;
     }
 
-    // Use longer delay for steps that require a mode switch to allow re-render
-    const delay = step.requiresMode ? 250 : 120;
+    let rafId: number;
+    let running = true;
 
-    const timer = setTimeout(() => {
+    // Initial delay for mode-switch steps to allow React re-render
+    const delay = step.requiresMode ? 300 : 50;
+
+    const track = () => {
+      if (!running) return;
       const el = document.querySelector(step.target!);
       if (el) {
-        setTargetRect(el.getBoundingClientRect());
+        const rect = el.getBoundingClientRect();
+        setTargetRect((prev) => {
+          // Only update state if the rect actually changed (avoids unnecessary re-renders)
+          if (
+            !prev ||
+            Math.abs(prev.left - rect.left) > 0.5 ||
+            Math.abs(prev.top - rect.top) > 0.5 ||
+            Math.abs(prev.width - rect.width) > 0.5 ||
+            Math.abs(prev.height - rect.height) > 0.5
+          ) {
+            return rect;
+          }
+          return prev;
+        });
       } else {
         setTargetRect(null);
       }
-    }, delay);
-
-    return () => clearTimeout(timer);
-  }, [open, step?.target, step?.requiresMode, currentStep]);
-
-  // Update on window resize
-  useEffect(() => {
-    if (!open || !step?.target) return;
-
-    const updateRect = () => {
-      const el = document.querySelector(step.target!);
-      if (el) {
-        setTargetRect(el.getBoundingClientRect());
-      }
+      rafId = requestAnimationFrame(track);
     };
 
-    window.addEventListener('resize', updateRect);
-    return () => window.removeEventListener('resize', updateRect);
-  }, [open, step?.target]);
+    const timer = setTimeout(() => {
+      track();
+    }, delay);
+
+    return () => {
+      running = false;
+      clearTimeout(timer);
+      cancelAnimationFrame(rafId);
+    };
+  }, [open, step?.target, step?.requiresMode, currentStep]);
 
   // Wrap onComplete to restore design mode if needed
   const handleComplete = useCallback(() => {
@@ -251,6 +264,49 @@ export function WorkflowBuilderTour({
 
   if (!open || !step) return null;
 
+  // Compute adjusted spotlight rect: clamp to viewport and expand for parent padding
+  const getSpotlightRect = () => {
+    if (!targetRect) return null;
+
+    let left = targetRect.left;
+    let top = targetRect.top;
+    let width = targetRect.width;
+    let height = targetRect.height;
+
+    // For inspector elements, expand left to cover the parent's pl-2 (8px) gap
+    if (
+      step.target === '[data-onboarding-builder="execution-inspector"]' ||
+      step.target === '[data-onboarding-builder="inspector-tabs"]'
+    ) {
+      left -= 8;
+      width += 8;
+    }
+
+    // Apply padding
+    left -= SPOTLIGHT_PADDING;
+    top -= SPOTLIGHT_PADDING;
+    width += SPOTLIGHT_PADDING * 2;
+    height += SPOTLIGHT_PADDING * 2;
+
+    // Clamp to viewport edges (fixes library panel at left edge)
+    if (left < 0) {
+      width += left; // shrink width by the amount clipped
+      left = 0;
+    }
+    if (top < 0) {
+      height += top;
+      top = 0;
+    }
+    if (left + width > window.innerWidth) {
+      width = window.innerWidth - left;
+    }
+    if (top + height > window.innerHeight) {
+      height = window.innerHeight - top;
+    }
+
+    return { left, top, width, height };
+  };
+
   const getTooltipStyle = (): React.CSSProperties => {
     if (isCenter || !targetRect) {
       return {
@@ -270,37 +326,51 @@ export function WorkflowBuilderTour({
       };
     }
 
-    // For the library panel, position to the right
+    // For the library panel (left side), position tooltip to the right of it
     if (step.target === '[data-onboarding-builder="library-panel"]') {
-      const tooltipTop = Math.max(80, targetRect.top + targetRect.height / 2 - 100);
+      const tooltipTop = Math.max(
+        80,
+        Math.min(window.innerHeight - 340, targetRect.top + targetRect.height / 2 - 100),
+      );
+      // Try full width first, then narrow width
+      const rightEdge = targetRect.right + TOOLTIP_GAP;
+      const fitsFullWidth = rightEdge + TOOLTIP_WIDTH <= window.innerWidth - 16;
+      const fitsNarrowWidth = rightEdge + TOOLTIP_WIDTH_NARROW <= window.innerWidth - 16;
+      const width = fitsFullWidth
+        ? TOOLTIP_WIDTH
+        : fitsNarrowWidth
+          ? TOOLTIP_WIDTH_NARROW
+          : Math.max(260, window.innerWidth - rightEdge - 16);
+
       return {
         top: tooltipTop,
-        left: targetRect.right + TOOLTIP_GAP,
-        width: TOOLTIP_WIDTH,
+        left: rightEdge,
+        width,
       };
     }
 
-    // For inspector elements (right panel), position to the left with bounds checking
+    // For inspector elements (right side), position tooltip to the left of it
     if (
       step.target === '[data-onboarding-builder="execution-inspector"]' ||
       step.target === '[data-onboarding-builder="inspector-tabs"]'
     ) {
-      const tooltipTop = Math.max(80, targetRect.top + targetRect.height / 2 - 100);
-      const leftPos = targetRect.left - TOOLTIP_WIDTH - TOOLTIP_GAP;
-
-      // If tooltip would go off-screen left, center it over the canvas area instead
-      if (leftPos < 16) {
-        return {
-          top: tooltipTop,
-          left: Math.max(16, (targetRect.left - TOOLTIP_WIDTH) / 2),
-          width: Math.min(TOOLTIP_WIDTH, targetRect.left - 32),
-        };
-      }
+      const tooltipTop = Math.max(
+        80,
+        Math.min(window.innerHeight - 340, targetRect.top + targetRect.height / 2 - 100),
+      );
+      // Try full width first, then narrow width
+      const fitsFullWidth = targetRect.left - TOOLTIP_GAP - TOOLTIP_WIDTH >= 16;
+      const fitsNarrowWidth = targetRect.left - TOOLTIP_GAP - TOOLTIP_WIDTH_NARROW >= 16;
+      const width = fitsFullWidth
+        ? TOOLTIP_WIDTH
+        : fitsNarrowWidth
+          ? TOOLTIP_WIDTH_NARROW
+          : Math.max(260, targetRect.left - TOOLTIP_GAP - 16);
 
       return {
         top: tooltipTop,
-        left: leftPos,
-        width: TOOLTIP_WIDTH,
+        left: targetRect.left - TOOLTIP_GAP - width,
+        width,
       };
     }
 
@@ -332,29 +402,37 @@ export function WorkflowBuilderTour({
       {isCenter || !targetRect ? (
         <div className="fixed inset-0 bg-black/60 backdrop-blur-[2px] transition-opacity duration-200" />
       ) : (
-        <>
-          <div
-            className="fixed rounded-xl transition-all duration-300 ease-out"
-            style={{
-              top: targetRect.top - SPOTLIGHT_PADDING,
-              left: targetRect.left - SPOTLIGHT_PADDING,
-              width: targetRect.width + SPOTLIGHT_PADDING * 2,
-              height: targetRect.height + SPOTLIGHT_PADDING * 2,
-              boxShadow: '0 0 0 9999px rgba(0, 0, 0, 0.6), 0 0 30px 8px rgba(99, 102, 241, 0.2)',
-              pointerEvents: 'none',
-            }}
-          />
-          <div
-            className="fixed rounded-xl border-2 border-primary/40 transition-all duration-300 ease-out animate-pulse"
-            style={{
-              top: targetRect.top - SPOTLIGHT_PADDING - 2,
-              left: targetRect.left - SPOTLIGHT_PADDING - 2,
-              width: targetRect.width + SPOTLIGHT_PADDING * 2 + 4,
-              height: targetRect.height + SPOTLIGHT_PADDING * 2 + 4,
-              pointerEvents: 'none',
-            }}
-          />
-        </>
+        (() => {
+          const spot = getSpotlightRect();
+          return spot ? (
+            <>
+              <div
+                className="fixed rounded-xl transition-all duration-300 ease-out"
+                style={{
+                  top: spot.top,
+                  left: spot.left,
+                  width: spot.width,
+                  height: spot.height,
+                  boxShadow:
+                    '0 0 0 9999px rgba(0, 0, 0, 0.6), 0 0 30px 8px rgba(99, 102, 241, 0.2)',
+                  pointerEvents: 'none',
+                }}
+              />
+              <div
+                className="fixed rounded-xl border-2 border-primary/40 transition-all duration-300 ease-out animate-pulse"
+                style={{
+                  top: spot.top - 2,
+                  left: spot.left - 2,
+                  width: spot.width + 4,
+                  height: spot.height + 4,
+                  pointerEvents: 'none',
+                }}
+              />
+            </>
+          ) : (
+            <div className="fixed inset-0 bg-black/60 backdrop-blur-[2px] transition-opacity duration-200" />
+          );
+        })()
       )}
 
       {/* Tooltip card */}
@@ -395,7 +473,7 @@ export function WorkflowBuilderTour({
         {/* Footer */}
         <div className="px-5 py-3 border-t border-border/40 bg-muted/20">
           <div className="flex items-center justify-between">
-            <div>
+            <div className="flex items-center gap-1">
               {currentStep > 0 && (
                 <Button
                   variant="ghost"
@@ -407,6 +485,14 @@ export function WorkflowBuilderTour({
                   Back
                 </Button>
               )}
+              <Button
+                variant="link"
+                size="sm"
+                onClick={handleComplete}
+                className="h-8 text-xs text-muted-foreground/60 hover:text-muted-foreground"
+              >
+                Skip tour
+              </Button>
             </div>
             <Button size="sm" onClick={handleNext} className="h-8 text-xs gap-1 px-4 shadow-sm">
               {isLastStep ? (

--- a/frontend/src/components/timeline/ExecutionInspector.tsx
+++ b/frontend/src/components/timeline/ExecutionInspector.tsx
@@ -250,7 +250,10 @@ export function ExecutionInspector({ onRerunRun }: ExecutionInspectorProps = {})
   const isMobile = useIsMobile();
   return (
     <>
-      <aside className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background">
+      <aside
+        data-onboarding-builder="execution-inspector"
+        className="flex h-full min-h-0 w-full flex-col overflow-hidden bg-background"
+      >
         {/* Header - Run Selector */}
         <div className="border-b px-3 py-2.5 flex items-center justify-between gap-2">
           <RunSelector
@@ -357,7 +360,10 @@ export function ExecutionInspector({ onRerunRun }: ExecutionInspectorProps = {})
 
         {/* Tabs */}
         <div className="border-b px-3 py-2 flex items-center justify-between gap-2 bg-muted/20">
-          <div className="inline-flex rounded-md border bg-background p-0.5 text-xs">
+          <div
+            data-onboarding-builder="inspector-tabs"
+            className="inline-flex rounded-md border bg-background p-0.5 text-xs"
+          >
             <Button
               variant={inspectorTab === 'events' ? 'default' : 'ghost'}
               size="sm"

--- a/frontend/src/components/workflow/WorkflowBuilderShell.tsx
+++ b/frontend/src/components/workflow/WorkflowBuilderShell.tsx
@@ -345,6 +345,7 @@ export function WorkflowBuilderShell({
 
         {/* Library Panel - Full screen overlay on mobile, side panel on desktop */}
         <aside
+          data-onboarding-builder="library-panel"
           className={cn(
             'h-full border-r bg-background overflow-hidden z-[60]',
             // Mobile: fixed overlay
@@ -406,7 +407,9 @@ export function WorkflowBuilderShell({
             transition: isInspectorResizing ? 'none' : 'all 200ms ease-in-out',
           }}
         >
-          <div className="flex-1 h-full relative min-w-0">{canvasContent}</div>
+          <div data-onboarding-builder="canvas" className="flex-1 h-full relative min-w-0">
+            {canvasContent}
+          </div>
 
           {/* Schedule Sidebar - Hide on mobile, show as drawer instead */}
           {showScheduleSidebarContainer && !isMobile && (

--- a/frontend/src/components/workflow/WorkflowSchedulesPanel.tsx
+++ b/frontend/src/components/workflow/WorkflowSchedulesPanel.tsx
@@ -28,7 +28,10 @@ export function WorkflowSchedulesSummaryBar({
   const countError = schedules.filter((s) => s.status === 'error').length;
 
   return (
-    <div className="pointer-events-auto flex items-center gap-2 md:gap-3 rounded-xl border bg-background/95 px-2 md:px-4 py-1.5 md:py-2 ring-1 ring-border/60 shadow-sm">
+    <div
+      data-onboarding-builder="schedule-bar"
+      className="pointer-events-auto flex items-center gap-2 md:gap-3 rounded-xl border bg-background/95 px-2 md:px-4 py-1.5 md:py-2 ring-1 ring-border/60 shadow-sm"
+    >
       <div className="flex items-center gap-2 md:gap-3">
         <div className="flex items-center justify-center w-8 h-8 rounded-lg bg-primary/10">
           <svg

--- a/frontend/src/features/workflow-builder/WorkflowBuilder.tsx
+++ b/frontend/src/features/workflow-builder/WorkflowBuilder.tsx
@@ -1094,7 +1094,7 @@ function WorkflowBuilderContent() {
         />
       )}
       <WorkflowBuilderTour
-        open={!hasCompletedBuilderTour && !isLoading && !isNewWorkflow && !isMobile}
+        open={!hasCompletedBuilderTour && !isLoading && !isMobile}
         onComplete={completeBuilderTour}
         currentStep={builderTourStep}
         onStepChange={setBuilderTourStep}

--- a/frontend/src/features/workflow-builder/WorkflowBuilder.tsx
+++ b/frontend/src/features/workflow-builder/WorkflowBuilder.tsx
@@ -168,9 +168,11 @@ function WorkflowBuilderContent() {
   const isMobile = useIsMobile();
 
   // Builder tour state (completion persisted in DB, step tracking is session-only)
-  const { data: userPreferences } = useUserPreferences();
+  const { data: userPreferences, isSuccess: prefsLoaded } = useUserPreferences();
   const updatePreferencesForTour = useUpdateUserPreferences();
-  const hasCompletedBuilderTour = userPreferences?.hasCompletedBuilderTour ?? true;
+  const hasCompletedBuilderTour = prefsLoaded
+    ? (userPreferences?.hasCompletedBuilderTour ?? false)
+    : true;
   const builderTourStep = useOnboardingStore((s) => s.builderTourStep);
   const setBuilderTourStep = useOnboardingStore((s) => s.setBuilderTourStep);
   const completeBuilderTour = () =>

--- a/frontend/src/features/workflow-builder/WorkflowBuilder.tsx
+++ b/frontend/src/features/workflow-builder/WorkflowBuilder.tsx
@@ -50,6 +50,8 @@ import { useAuthStore } from '@/store/authStore';
 import { hasAdminRole } from '@/utils/auth';
 import { track, Events } from '@/features/analytics/events';
 import { useIsMobile } from '@/hooks/useIsMobile';
+import { WorkflowBuilderTour } from '@/components/onboarding/WorkflowBuilderTour';
+import { useOnboardingStore } from '@/store/onboardingStore';
 
 const ENTRY_DEFAULT_RUNTIME_INPUTS = [
   {
@@ -160,6 +162,12 @@ function WorkflowBuilderContent() {
   const selectedRunId = useExecutionTimelineStore((state) => state.selectedRunId);
   const selectedRun = selectedRunId ? (getRunByIdFromCache(selectedRunId) ?? null) : null;
   const isMobile = useIsMobile();
+
+  // Builder tour state
+  const hasCompletedBuilderTour = useOnboardingStore((s) => s.hasCompletedBuilderTour);
+  const builderTourStep = useOnboardingStore((s) => s.builderTourStep);
+  const setBuilderTourStep = useOnboardingStore((s) => s.setBuilderTourStep);
+  const completeBuilderTour = useOnboardingStore((s) => s.completeBuilderTour);
 
   // Undo/redo history management
   const { undo, redo, canUndo, canRedo, captureSnapshot, initializeHistory } = useWorkflowHistory({
@@ -1085,6 +1093,12 @@ function WorkflowBuilderContent() {
           onOpenChange={setIsPublishModalOpen}
         />
       )}
+      <WorkflowBuilderTour
+        open={!hasCompletedBuilderTour && !isLoading && !isNewWorkflow && !isMobile}
+        onComplete={completeBuilderTour}
+        currentStep={builderTourStep}
+        onStepChange={setBuilderTourStep}
+      />
     </>
   );
 }

--- a/frontend/src/features/workflow-builder/WorkflowBuilder.tsx
+++ b/frontend/src/features/workflow-builder/WorkflowBuilder.tsx
@@ -52,6 +52,10 @@ import { track, Events } from '@/features/analytics/events';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { WorkflowBuilderTour } from '@/components/onboarding/WorkflowBuilderTour';
 import { useOnboardingStore } from '@/store/onboardingStore';
+import {
+  useUserPreferences,
+  useUpdateUserPreferences,
+} from '@/hooks/queries/useUserPreferencesQueries';
 
 const ENTRY_DEFAULT_RUNTIME_INPUTS = [
   {
@@ -163,11 +167,14 @@ function WorkflowBuilderContent() {
   const selectedRun = selectedRunId ? (getRunByIdFromCache(selectedRunId) ?? null) : null;
   const isMobile = useIsMobile();
 
-  // Builder tour state
-  const hasCompletedBuilderTour = useOnboardingStore((s) => s.hasCompletedBuilderTour);
+  // Builder tour state (completion persisted in DB, step tracking is session-only)
+  const { data: userPreferences } = useUserPreferences();
+  const updatePreferencesForTour = useUpdateUserPreferences();
+  const hasCompletedBuilderTour = userPreferences?.hasCompletedBuilderTour ?? true;
   const builderTourStep = useOnboardingStore((s) => s.builderTourStep);
   const setBuilderTourStep = useOnboardingStore((s) => s.setBuilderTourStep);
-  const completeBuilderTour = useOnboardingStore((s) => s.completeBuilderTour);
+  const completeBuilderTour = () =>
+    updatePreferencesForTour.mutate({ hasCompletedBuilderTour: true });
 
   // Undo/redo history management
   const { undo, redo, canUndo, canRedo, captureSnapshot, initializeHistory } = useWorkflowHistory({

--- a/frontend/src/hooks/queries/useUserPreferencesQueries.ts
+++ b/frontend/src/hooks/queries/useUserPreferencesQueries.ts
@@ -1,0 +1,42 @@
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import { api } from '@/services/api';
+import { queryKeys } from '@/lib/queryKeys';
+
+interface UserPreferences {
+  hasCompletedOnboarding: boolean;
+  hasCompletedBuilderTour: boolean;
+}
+
+export function useUserPreferences() {
+  return useQuery({
+    queryKey: queryKeys.userPreferences.me(),
+    queryFn: () => api.userPreferences.get(),
+    staleTime: 5 * 60_000,
+    refetchOnWindowFocus: false,
+  });
+}
+
+export function useUpdateUserPreferences() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (prefs: Partial<UserPreferences>) => api.userPreferences.update(prefs),
+    onMutate: async (newPrefs) => {
+      await qc.cancelQueries({ queryKey: queryKeys.userPreferences.me() });
+      const previous = qc.getQueryData<UserPreferences>(queryKeys.userPreferences.me());
+      qc.setQueryData<UserPreferences>(queryKeys.userPreferences.me(), (old) => ({
+        hasCompletedOnboarding: old?.hasCompletedOnboarding ?? false,
+        hasCompletedBuilderTour: old?.hasCompletedBuilderTour ?? false,
+        ...newPrefs,
+      }));
+      return { previous };
+    },
+    onError: (_err, _newPrefs, context) => {
+      if (context?.previous) {
+        qc.setQueryData(queryKeys.userPreferences.me(), context.previous);
+      }
+    },
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.userPreferences.me() });
+    },
+  });
+}

--- a/frontend/src/lib/queryKeys.ts
+++ b/frontend/src/lib/queryKeys.ts
@@ -75,4 +75,7 @@ export const queryKeys = {
     runtimeInputs: (workflowId: string) =>
       ['workflowRuntimeInputs', getOrgScope(), workflowId] as const,
   },
+  userPreferences: {
+    me: () => ['userPreferences', getOrgScope(), getUserScope()] as const,
+  },
 } as const;

--- a/frontend/src/services/api.ts
+++ b/frontend/src/services/api.ts
@@ -1034,6 +1034,32 @@ export const api = {
     },
   },
 
+  userPreferences: {
+    get: async (): Promise<{
+      hasCompletedOnboarding: boolean;
+      hasCompletedBuilderTour: boolean;
+    }> => {
+      const headers = await getAuthHeaders();
+      const response = await fetch(`${API_V1_URL}/users/me/preferences`, { headers });
+      if (!response.ok) throw new Error('Failed to fetch user preferences');
+      return response.json();
+    },
+
+    update: async (prefs: {
+      hasCompletedOnboarding?: boolean;
+      hasCompletedBuilderTour?: boolean;
+    }): Promise<{ hasCompletedOnboarding: boolean; hasCompletedBuilderTour: boolean }> => {
+      const headers = await getAuthHeaders();
+      const response = await fetch(`${API_V1_URL}/users/me/preferences`, {
+        method: 'PATCH',
+        headers: { ...headers, 'Content-Type': 'application/json' },
+        body: JSON.stringify(prefs),
+      });
+      if (!response.ok) throw new Error('Failed to update user preferences');
+      return response.json();
+    },
+  },
+
   webhooks: {
     list: async (): Promise<WebhookConfiguration[]> => {
       const response = await apiClient.listWebhookConfigurations();

--- a/frontend/src/store/onboardingStore.ts
+++ b/frontend/src/store/onboardingStore.ts
@@ -1,0 +1,30 @@
+import { create } from 'zustand';
+import { persist } from 'zustand/middleware';
+
+interface OnboardingState {
+  hasCompletedOnboarding: boolean;
+  currentStep: number;
+  setCurrentStep: (step: number) => void;
+  nextStep: () => void;
+  prevStep: () => void;
+  completeOnboarding: () => void;
+  resetOnboarding: () => void;
+}
+
+export const useOnboardingStore = create<OnboardingState>()(
+  persist(
+    (set, get) => ({
+      hasCompletedOnboarding: false,
+      currentStep: 0,
+      setCurrentStep: (step) => set({ currentStep: step }),
+      nextStep: () => set({ currentStep: Math.min(5, get().currentStep + 1) }),
+      prevStep: () => set({ currentStep: Math.max(0, get().currentStep - 1) }),
+      completeOnboarding: () => set({ hasCompletedOnboarding: true, currentStep: 0 }),
+      resetOnboarding: () => set({ hasCompletedOnboarding: false, currentStep: 0 }),
+    }),
+    {
+      name: 'shipsec-onboarding',
+      partialize: (state) => ({ hasCompletedOnboarding: state.hasCompletedOnboarding }), // Only persist hasCompletedOnboarding, not currentStep
+    },
+  ),
+);

--- a/frontend/src/store/onboardingStore.ts
+++ b/frontend/src/store/onboardingStore.ts
@@ -9,6 +9,13 @@ interface OnboardingState {
   prevStep: () => void;
   completeOnboarding: () => void;
   resetOnboarding: () => void;
+
+  // Workflow Builder tour
+  hasCompletedBuilderTour: boolean;
+  builderTourStep: number;
+  setBuilderTourStep: (step: number) => void;
+  completeBuilderTour: () => void;
+  resetBuilderTour: () => void;
 }
 
 export const useOnboardingStore = create<OnboardingState>()(
@@ -21,10 +28,20 @@ export const useOnboardingStore = create<OnboardingState>()(
       prevStep: () => set({ currentStep: Math.max(0, get().currentStep - 1) }),
       completeOnboarding: () => set({ hasCompletedOnboarding: true, currentStep: 0 }),
       resetOnboarding: () => set({ hasCompletedOnboarding: false, currentStep: 0 }),
+
+      // Workflow Builder tour
+      hasCompletedBuilderTour: false,
+      builderTourStep: 0,
+      setBuilderTourStep: (step) => set({ builderTourStep: step }),
+      completeBuilderTour: () => set({ hasCompletedBuilderTour: true, builderTourStep: 0 }),
+      resetBuilderTour: () => set({ hasCompletedBuilderTour: false, builderTourStep: 0 }),
     }),
     {
       name: 'shipsec-onboarding',
-      partialize: (state) => ({ hasCompletedOnboarding: state.hasCompletedOnboarding }), // Only persist hasCompletedOnboarding, not currentStep
+      partialize: (state) => ({
+        hasCompletedOnboarding: state.hasCompletedOnboarding,
+        hasCompletedBuilderTour: state.hasCompletedBuilderTour,
+      }),
     },
   ),
 );

--- a/frontend/src/store/onboardingStore.ts
+++ b/frontend/src/store/onboardingStore.ts
@@ -1,47 +1,27 @@
 import { create } from 'zustand';
-import { persist } from 'zustand/middleware';
 
 interface OnboardingState {
-  hasCompletedOnboarding: boolean;
+  // Session-only step tracking (not persisted)
   currentStep: number;
   setCurrentStep: (step: number) => void;
   nextStep: () => void;
   prevStep: () => void;
-  completeOnboarding: () => void;
-  resetOnboarding: () => void;
+  resetSteps: () => void;
 
-  // Workflow Builder tour
-  hasCompletedBuilderTour: boolean;
+  // Workflow Builder tour step tracking (not persisted)
   builderTourStep: number;
   setBuilderTourStep: (step: number) => void;
-  completeBuilderTour: () => void;
-  resetBuilderTour: () => void;
+  resetBuilderTourStep: () => void;
 }
 
-export const useOnboardingStore = create<OnboardingState>()(
-  persist(
-    (set, get) => ({
-      hasCompletedOnboarding: false,
-      currentStep: 0,
-      setCurrentStep: (step) => set({ currentStep: step }),
-      nextStep: () => set({ currentStep: Math.min(5, get().currentStep + 1) }),
-      prevStep: () => set({ currentStep: Math.max(0, get().currentStep - 1) }),
-      completeOnboarding: () => set({ hasCompletedOnboarding: true, currentStep: 0 }),
-      resetOnboarding: () => set({ hasCompletedOnboarding: false, currentStep: 0 }),
+export const useOnboardingStore = create<OnboardingState>()((set, get) => ({
+  currentStep: 0,
+  setCurrentStep: (step) => set({ currentStep: step }),
+  nextStep: () => set({ currentStep: Math.min(5, get().currentStep + 1) }),
+  prevStep: () => set({ currentStep: Math.max(0, get().currentStep - 1) }),
+  resetSteps: () => set({ currentStep: 0 }),
 
-      // Workflow Builder tour
-      hasCompletedBuilderTour: false,
-      builderTourStep: 0,
-      setBuilderTourStep: (step) => set({ builderTourStep: step }),
-      completeBuilderTour: () => set({ hasCompletedBuilderTour: true, builderTourStep: 0 }),
-      resetBuilderTour: () => set({ hasCompletedBuilderTour: false, builderTourStep: 0 }),
-    }),
-    {
-      name: 'shipsec-onboarding',
-      partialize: (state) => ({
-        hasCompletedOnboarding: state.hasCompletedOnboarding,
-        hasCompletedBuilderTour: state.hasCompletedBuilderTour,
-      }),
-    },
-  ),
-);
+  builderTourStep: 0,
+  setBuilderTourStep: (step) => set({ builderTourStep: step }),
+  resetBuilderTourStep: () => set({ builderTourStep: 0 }),
+}));


### PR DESCRIPTION
## Summary

Adds a complete first-time user onboarding system with two spotlight-based guided tours and server-side state persistence.

### Tour 1: App Navigation Tour
- Welcome dialog introducing ShipSec Studio
- Spotlight highlights for: Workflow Builder, Template Library, Schedules, Action Center, and Manage Settings (sidebar sections)
- Keyboard navigation (Arrow keys, Escape)
- Skip tour button

### Tour 2: Workflow Builder Tour
- Triggers automatically on first visit to the workflow builder after completing Tour 1
- 10-step guided walkthrough covering: Canvas, Component Library, Node Inspector, Top Bar Actions, Mode Switching (Design/Execute), Execution Inspector, Inspector Tabs, Schedules, and Publish
- Auto-switches between Design and Execute modes to demonstrate each context
- Responsive tooltip positioning with width cascade (380px → 320px → fit)
- `requestAnimationFrame` continuous tracking for accurate spotlight positioning during layout transitions

### State Persistence (Database-backed)
- **`user_preferences` table** with Drizzle ORM schema — composite PK `(userId, organizationId)`, stores `has_completed_onboarding` and `has_completed_builder_tour` booleans
- **Backend API**: `GET /api/v1/users/me/preferences` and `PATCH /api/v1/users/me/preferences` with NestJS module (controller, service, repository)
- **Frontend**: TanStack Query hooks with optimistic updates for instant UI response
- **Migration**: One-time localStorage → DB migration for existing users, auto-cleans up after sync
- Table is auto-created on backend startup via `drizzle-kit push`

### UI/UX
- Spotlight cutout using `box-shadow: 0 0 0 9999px` technique with animated pulse border
- Gradient-themed tooltip cards per step with icons
- Portal-rendered overlay at z-index 200
- Loading guard prevents dialog flash on page load
- Skip tour and Back/Next navigation in both tours

### Other Changes
- Top bar dropdown reordered: Undo/Redo → Import/Export → separator → Publish as Template → View Analytics
- Pinned bun to 1.3.9 to fix NestJS decorator regression in 1.3.10

## Files Added
- `backend/src/database/schema/user-preferences.ts` — Drizzle table schema
- `backend/src/user-preferences/` — NestJS module (controller, service, repository, dto, module)
- `frontend/src/components/onboarding/OnboardingDialog.tsx` — App navigation tour dialog
- `frontend/src/components/onboarding/WorkflowBuilderTour.tsx` — Workflow builder tour
- `frontend/src/hooks/queries/useUserPreferencesQueries.ts` — TanStack Query hooks
- `frontend/src/store/onboardingStore.ts` — Session-only step tracking (Zustand, no persist)

## Files Modified
- `frontend/src/components/layout/AppLayout.tsx` — Tour 1 integration, DB-backed state, localStorage migration
- `frontend/src/features/workflow-builder/WorkflowBuilder.tsx` — Tour 2 integration, DB-backed state
- `frontend/src/components/layout/TopBar.tsx` — Dropdown reorder, data-onboarding attributes
- `frontend/src/services/api.ts` — User preferences API endpoints
- `frontend/src/lib/queryKeys.ts` — User preferences query key
- `backend/src/app.module.ts` — Register UserPreferencesModule
- `backend/src/database/schema/index.ts` — Export user-preferences schema

## Test Plan
- [ ] Fresh user: App tour appears on first login, all 6 steps highlight correct sidebar items
- [ ] Complete app tour → navigate to workflow builder → builder tour starts automatically
- [ ] Builder tour: all 10 steps highlight correct elements, mode switching works
- [ ] Skip tour button dismisses both tours
- [ ] Refresh page after completing tours → tours do not reappear
- [ ] Check `user_preferences` table in DB shows `has_completed_onboarding = true`
- [ ] Existing localStorage users: state migrates to DB, localStorage key removed
- [ ] Keyboard nav: Arrow Right/Left for next/back, Escape to close
- [ ] Responsive: tooltips don't overflow on smaller screens